### PR TITLE
feat: add measurement manager for unified sizing

### DIFF
--- a/src/MeasurementManager.js
+++ b/src/MeasurementManager.js
@@ -1,0 +1,34 @@
+export class MeasurementManager {
+  static screenWidth = 1024;
+  static screenHeight = 768;
+
+  static get centerX() {
+    return this.screenWidth / 2;
+  }
+
+  static get centerY() {
+    return this.screenHeight / 2;
+  }
+
+  static progressBar = {
+    width: 468,
+    height: 32,
+    offsetX: 230,
+    fillStartWidth: 4,
+    fillHeight: 28,
+    fillMaxWidth: 460,
+  };
+
+  static mainMenu = {
+    logoOffsetY: -84,
+    titleOffsetY: 76,
+  };
+
+  static fontSizes = {
+    default: 24,
+    mainMenuTitle: 38,
+    gameOverTitle: 64,
+  };
+
+  static strokeThickness = 8;
+}

--- a/src/game/main.js
+++ b/src/game/main.js
@@ -6,11 +6,12 @@ import { DungeonExplorationState } from './states/DungeonExplorationState';
 import { CombatState } from './states/CombatState';
 import { gameStateManager } from './states/GameStateManager';
 import { AUTO, Game } from 'phaser';
+import { MeasurementManager } from '../MeasurementManager';
 
 const config = {
     type: AUTO,
-    width: 1024,
-    height: 768,
+    width: MeasurementManager.screenWidth,
+    height: MeasurementManager.screenHeight,
     parent: 'game-container',
     backgroundColor: '#028af8',
     scale: {

--- a/src/game/scenes/GameOver.js
+++ b/src/game/scenes/GameOver.js
@@ -1,4 +1,5 @@
 import { Scene } from 'phaser';
+import { MeasurementManager } from '../../MeasurementManager';
 
 export class GameOver extends Scene
 {
@@ -11,11 +12,13 @@ export class GameOver extends Scene
     {
         this.cameras.main.setBackgroundColor(0xff0000);
 
-        this.add.image(512, 384, 'background').setAlpha(0.5);
+        const { centerX, centerY } = MeasurementManager;
 
-        this.add.text(512, 384, 'Game Over', {
-            fontFamily: 'Arial Black', fontSize: 64, color: '#ffffff',
-            stroke: '#000000', strokeThickness: 8,
+        this.add.image(centerX, centerY, 'background').setAlpha(0.5);
+
+        this.add.text(centerX, centerY, 'Game Over', {
+            fontFamily: 'Arial Black', fontSize: MeasurementManager.fontSizes.gameOverTitle, color: '#ffffff',
+            stroke: '#000000', strokeThickness: MeasurementManager.strokeThickness,
             align: 'center'
         }).setOrigin(0.5);
 

--- a/src/game/scenes/MainMenu.js
+++ b/src/game/scenes/MainMenu.js
@@ -1,5 +1,6 @@
 import { Scene } from 'phaser';
 import { gameStateManager, GameStates } from '../states/GameStateManager';
+import { MeasurementManager } from '../../MeasurementManager';
 
 export class MainMenu extends Scene
 {
@@ -10,13 +11,15 @@ export class MainMenu extends Scene
 
     create ()
     {
-        this.add.image(512, 384, 'background');
+        const { centerX, centerY, mainMenu } = MeasurementManager;
 
-        this.add.image(512, 300, 'logo');
+        this.add.image(centerX, centerY, 'background');
 
-        this.add.text(512, 460, 'Main Menu', {
-            fontFamily: 'Arial Black', fontSize: 38, color: '#ffffff',
-            stroke: '#000000', strokeThickness: 8,
+        this.add.image(centerX, centerY + mainMenu.logoOffsetY, 'logo');
+
+        this.add.text(centerX, centerY + mainMenu.titleOffsetY, 'Main Menu', {
+            fontFamily: 'Arial Black', fontSize: MeasurementManager.fontSizes.mainMenuTitle, color: '#ffffff',
+            stroke: '#000000', strokeThickness: MeasurementManager.strokeThickness,
             align: 'center'
         }).setOrigin(0.5);
 

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -1,4 +1,5 @@
 import { Scene } from 'phaser';
+import { MeasurementManager } from '../../MeasurementManager';
 
 export class Preloader extends Scene
 {
@@ -10,19 +11,27 @@ export class Preloader extends Scene
     init ()
     {
         //  We loaded this image in our Boot Scene, so we can display it here
-        this.add.image(512, 384, 'background');
+        this.add.image(MeasurementManager.centerX, MeasurementManager.centerY, 'background');
 
         //  A simple progress bar. This is the outline of the bar.
-        this.add.rectangle(512, 384, 468, 32).setStrokeStyle(1, 0xffffff);
+        this.add.rectangle(MeasurementManager.centerX, MeasurementManager.centerY, MeasurementManager.progressBar.width, MeasurementManager.progressBar.height).setStrokeStyle(1, 0xffffff);
 
         //  This is the progress bar itself. It will increase in size from the left based on the % of progress.
-        const bar = this.add.rectangle(512-230, 384, 4, 28, 0xffffff);
+        const bar = this.add.rectangle(
+            MeasurementManager.centerX - MeasurementManager.progressBar.offsetX,
+            MeasurementManager.centerY,
+            MeasurementManager.progressBar.fillStartWidth,
+            MeasurementManager.progressBar.fillHeight,
+            0xffffff
+        );
 
         //  Use the 'progress' event emitted by the LoaderPlugin to update the loading bar
         this.load.on('progress', (progress) => {
 
             //  Update the progress bar (our bar is 464px wide, so 100% = 464px)
-            bar.width = 4 + (460 * progress);
+            bar.width =
+                MeasurementManager.progressBar.fillStartWidth +
+                MeasurementManager.progressBar.fillMaxWidth * progress;
 
         });
     }

--- a/src/game/states/CombatState.js
+++ b/src/game/states/CombatState.js
@@ -1,5 +1,6 @@
 import { Scene } from 'phaser';
 import { gameStateManager, GameStates } from './GameStateManager';
+import { MeasurementManager } from '../../MeasurementManager';
 
 export class CombatState extends Scene {
   constructor() {
@@ -7,9 +8,11 @@ export class CombatState extends Scene {
   }
 
   create() {
-    this.add.text(512, 384, 'Combat', {
+    const { centerX, centerY } = MeasurementManager;
+
+    this.add.text(centerX, centerY, 'Combat', {
       fontFamily: 'Arial',
-      fontSize: 24,
+      fontSize: MeasurementManager.fontSizes.default,
       color: '#ffffff'
     }).setOrigin(0.5);
 

--- a/src/game/states/DungeonExplorationState.js
+++ b/src/game/states/DungeonExplorationState.js
@@ -1,6 +1,7 @@
 import { Scene } from 'phaser';
 import { gameStateManager, GameStates } from './GameStateManager';
 import { Entity, PositionComponent, StatsComponent } from '../../ecs';
+import { MeasurementManager } from '../../MeasurementManager';
 
 export class DungeonExplorationState extends Scene {
   constructor() {
@@ -12,9 +13,11 @@ export class DungeonExplorationState extends Scene {
       .addComponent(new PositionComponent(0, 0))
       .addComponent(new StatsComponent(100, 10));
 
-    this.add.text(512, 384, 'Dungeon Exploration', {
+    const { centerX, centerY } = MeasurementManager;
+
+    this.add.text(centerX, centerY, 'Dungeon Exploration', {
       fontFamily: 'Arial',
-      fontSize: 24,
+      fontSize: MeasurementManager.fontSizes.default,
       color: '#ffffff'
     }).setOrigin(0.5);
 


### PR DESCRIPTION
## Summary
- add measurement manager to centralize screen, progress bar, and font sizes
- use measurement manager across scenes and states for consistent layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c68e0b722c8327b29a4d2dd711edc4