### PR TITLE
feat: add debug log manager

### DIFF
--- a/src/game/main.js
+++ b/src/game/main.js
@@ -6,6 +6,7 @@ import { DungeonExplorationState } from './states/DungeonExplorationState';
 import { CombatState } from './states/CombatState';
 import { gameStateManager } from './states/GameStateManager';
 import { AUTO, Game } from 'phaser';
+import { debugLogManager } from '../utils/DebugLogManager';
 
 const config = {
     type: AUTO,
@@ -28,8 +29,10 @@ const config = {
 };
 
 const StartGame = (parent) => {
+    debugLogManager.init(import.meta.env?.DEV);
     const game = new Game({ ...config, parent });
     gameStateManager.init(game);
+    debugLogManager.log('Game initialized', { parent });
     return game;
 }
 

--- a/src/game/states/CombatState.js
+++ b/src/game/states/CombatState.js
@@ -1,5 +1,6 @@
 import { Scene } from 'phaser';
 import { gameStateManager, GameStates } from './GameStateManager';
+import { debugLogManager } from '../../utils/DebugLogManager';
 
 export class CombatState extends Scene {
   constructor() {
@@ -7,6 +8,7 @@ export class CombatState extends Scene {
   }
 
   create() {
+    debugLogManager.log('Combat state entered');
     this.add.text(512, 384, 'Combat', {
       fontFamily: 'Arial',
       fontSize: 24,
@@ -14,6 +16,7 @@ export class CombatState extends Scene {
     }).setOrigin(0.5);
 
     this.input.once('pointerdown', () => {
+      debugLogManager.log('Combat pointerdown');
       gameStateManager.changeState(GameStates.DUNGEON);
     });
   }

--- a/src/game/states/DungeonExplorationState.js
+++ b/src/game/states/DungeonExplorationState.js
@@ -1,6 +1,7 @@
 import { Scene } from 'phaser';
 import { gameStateManager, GameStates } from './GameStateManager';
 import { Entity, PositionComponent, StatsComponent } from '../../ecs';
+import { debugLogManager } from '../../utils/DebugLogManager';
 
 export class DungeonExplorationState extends Scene {
   constructor() {
@@ -8,9 +9,14 @@ export class DungeonExplorationState extends Scene {
   }
 
   create() {
+    debugLogManager.log('Dungeon exploration state entered');
     this.player = new Entity('player')
       .addComponent(new PositionComponent(0, 0))
       .addComponent(new StatsComponent(100, 10));
+    debugLogManager.log('Player entity created', {
+      id: this.player.id,
+      stats: this.player.getComponent(StatsComponent)
+    });
 
     this.add.text(512, 384, 'Dungeon Exploration', {
       fontFamily: 'Arial',
@@ -19,6 +25,7 @@ export class DungeonExplorationState extends Scene {
     }).setOrigin(0.5);
 
     this.input.once('pointerdown', () => {
+      debugLogManager.log('Dungeon pointerdown');
       gameStateManager.changeState(GameStates.COMBAT);
     });
   }

--- a/src/game/states/GameStateManager.js
+++ b/src/game/states/GameStateManager.js
@@ -1,3 +1,5 @@
+import { debugLogManager } from '../../utils/DebugLogManager';
+
 export const GameStates = {
   DUNGEON: 'DungeonExplorationState',
   COMBAT: 'CombatState'
@@ -6,12 +8,18 @@ export const GameStates = {
 class GameStateManager {
   init(game) {
     this.game = game;
+    this.currentState = null;
   }
 
   changeState(stateKey) {
     if (!this.game) {
       throw new Error('GameStateManager not initialized');
     }
+    debugLogManager.log('State change', {
+      from: this.currentState,
+      to: stateKey
+    });
+    this.currentState = stateKey;
     this.game.scene.start(stateKey);
   }
 }

--- a/src/utils/DebugLogManager.js
+++ b/src/utils/DebugLogManager.js
@@ -1,0 +1,34 @@
+class DebugLogManager {
+  constructor() {
+    this.enabled = false;
+    this.entries = [];
+  }
+
+  init(enabled = false) {
+    this.enabled = enabled;
+  }
+
+  log(message, context = {}) {
+    if (!this.enabled) {
+      return;
+    }
+    const entry = {
+      timestamp: new Date().toISOString(),
+      message,
+      context
+    };
+    this.entries.push(entry);
+    // eslint-disable-next-line no-console
+    console.debug(`[DEV] ${message}`, context);
+  }
+
+  getLogs() {
+    return [...this.entries];
+  }
+
+  clear() {
+    this.entries.length = 0;
+  }
+}
+
+export const debugLogManager = new DebugLogManager();


### PR DESCRIPTION
## Summary
- add centralized debug log manager to capture developer mode events
- initialize and use log manager across game states

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68c68e9e8a2483278b9ef3adf161a226