### PR TITLE
feat: scaffold event-driven architecture

### DIFF
--- a/src/core/components.js
+++ b/src/core/components.js
@@ -1,0 +1,6 @@
+// Core component definitions: pure data only
+// Example components used by entities in the global state
+
+export const Position = (x = 0, y = 0) => ({ x, y });
+
+export const Stats = (hp = 100, mp = 0) => ({ hp, mp });

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -1,0 +1,13 @@
+// Centralized game state: holds all world and entity data
+
+export const state = {
+  world: {},
+  entities: new Map()
+};
+
+let nextId = 1;
+export const createEntity = (components = {}) => {
+  const id = nextId++;
+  state.entities.set(id, components);
+  return id;
+};

--- a/src/events/EventBus.js
+++ b/src/events/EventBus.js
@@ -1,0 +1,21 @@
+// Simple event bus for decoupled communication between systems
+
+export class EventBus {
+  constructor() {
+    this.listeners = {};
+  }
+
+  on(type, handler) {
+    if (!this.listeners[type]) {
+      this.listeners[type] = new Set();
+    }
+    this.listeners[type].add(handler);
+    return () => this.listeners[type]?.delete(handler);
+  }
+
+  emit(type, payload) {
+    this.listeners[type]?.forEach((handler) => handler(payload));
+  }
+}
+
+export const eventBus = new EventBus();

--- a/src/events/eventTypes.js
+++ b/src/events/eventTypes.js
@@ -1,0 +1,5 @@
+// Central definition of all event type strings
+
+export const PLAYER_MOVED = 'PLAYER_MOVED';
+export const ENEMY_DIED = 'ENEMY_DIED';
+export const MOVE_REQUEST = 'MOVE_REQUEST';

--- a/src/scenes/CombatScene.js
+++ b/src/scenes/CombatScene.js
@@ -1,0 +1,14 @@
+import Phaser from 'phaser';
+import { eventBus } from '../events/EventBus.js';
+
+export class CombatScene extends Phaser.Scene {
+  constructor() {
+    super('CombatScene');
+  }
+
+  create() {
+    eventBus.on('ENEMY_DIED', () => {
+      // update combat visuals
+    });
+  }
+}

--- a/src/scenes/DungeonScene.js
+++ b/src/scenes/DungeonScene.js
@@ -1,0 +1,15 @@
+import Phaser from 'phaser';
+import { eventBus } from '../events/EventBus.js';
+
+export class DungeonScene extends Phaser.Scene {
+  constructor() {
+    super('DungeonScene');
+  }
+
+  create() {
+    // listen for player movement events and update visuals
+    eventBus.on('PLAYER_MOVED', ({ x, y }) => {
+      // drawing logic placeholder
+    });
+  }
+}

--- a/src/systems/aiSystem.js
+++ b/src/systems/aiSystem.js
@@ -1,0 +1,10 @@
+// AI decision making placeholder
+export const aiSystem = (bus, state) => {
+  const id = 'ai';
+
+  const init = () => {};
+
+  const update = () => {};
+
+  return { id, init, update };
+};

--- a/src/systems/combatSystem.js
+++ b/src/systems/combatSystem.js
@@ -1,0 +1,12 @@
+import { ENEMY_DIED } from '../events/eventTypes.js';
+
+// Placeholder for the current Wizardry-style combat logic
+export const combatSystem = (bus, state) => {
+  const id = 'combat';
+
+  const init = () => {};
+
+  const update = () => {};
+
+  return { id, init, update };
+};

--- a/src/systems/index.js
+++ b/src/systems/index.js
@@ -1,0 +1,31 @@
+// System manager to register, enable and disable game systems
+
+export const createSystemManager = (bus, state) => {
+  const systems = new Map();
+
+  const register = (factory) => {
+    const system = factory(bus, state);
+    systems.set(system.id, { ...system, enabled: true });
+    system.init?.();
+  };
+
+  const enable = (id) => {
+    const sys = systems.get(id);
+    if (sys) sys.enabled = true;
+  };
+
+  const disable = (id) => {
+    const sys = systems.get(id);
+    if (sys) sys.enabled = false;
+  };
+
+  const update = (dt) => {
+    systems.forEach((sys) => {
+      if (sys.enabled) {
+        sys.update?.(dt);
+      }
+    });
+  };
+
+  return { register, enable, disable, update };
+};

--- a/src/systems/movementSystem.js
+++ b/src/systems/movementSystem.js
@@ -1,0 +1,20 @@
+import { MOVE_REQUEST, PLAYER_MOVED } from '../events/eventTypes.js';
+
+export const movementSystem = (bus, state) => {
+  const id = 'movement';
+
+  const init = () => {
+    bus.on(MOVE_REQUEST, ({ id: entityId, x, y }) => {
+      const entity = state.entities.get(entityId);
+      if (entity?.position) {
+        entity.position.x = x;
+        entity.position.y = y;
+        bus.emit(PLAYER_MOVED, { id: entityId, x, y });
+      }
+    });
+  };
+
+  const update = () => {};
+
+  return { id, init, update };
+};


### PR DESCRIPTION
## Summary
- establish core data layer and global state
- introduce central event bus with shared event types
- add system manager for registering and toggling systems with sample systems and scenes

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c6916278e88327b91280536bc06fb5