### PR TITLE
feat: add hierarchical feature manager

### DIFF
--- a/src/events/eventTypes.js
+++ b/src/events/eventTypes.js
@@ -3,3 +3,6 @@
 export const PLAYER_MOVED = 'PLAYER_MOVED';
 export const ENEMY_DIED = 'ENEMY_DIED';
 export const MOVE_REQUEST = 'MOVE_REQUEST';
+export const CAST_SPELL = 'CAST_SPELL';
+export const ITEM_USED = 'ITEM_USED';
+export const TARGET_SELECTED = 'TARGET_SELECTED';

--- a/src/features/FeatureManager.js
+++ b/src/features/FeatureManager.js
@@ -1,0 +1,38 @@
+export class FeatureManager {
+  constructor() {
+    this.features = new Map();
+  }
+
+  registerFeature(id, { systems = [], children = [] } = {}) {
+    if (this.features.has(id)) {
+      throw new Error(`Feature ${id} already registered`);
+    }
+    this.features.set(id, { id, systems, children, enabled: false });
+  }
+
+  enableFeature(id) {
+    const feature = this.features.get(id);
+    if (!feature || feature.enabled) {
+      return;
+    }
+    feature.enabled = true;
+    feature.systems.forEach((system) => system.start?.());
+    feature.children.forEach((childId) => this.enableFeature(childId));
+  }
+
+  disableFeature(id) {
+    const feature = this.features.get(id);
+    if (!feature || !feature.enabled) {
+      return;
+    }
+    feature.children.forEach((childId) => this.disableFeature(childId));
+    feature.systems.forEach((system) => system.stop?.());
+    feature.enabled = false;
+  }
+
+  isEnabled(id) {
+    return !!this.features.get(id)?.enabled;
+  }
+}
+
+export const featureManager = new FeatureManager();

--- a/src/features/combat/systems/itemSystem.js
+++ b/src/features/combat/systems/itemSystem.js
@@ -1,0 +1,14 @@
+import { eventBus } from '../../../events/EventBus.js';
+import { ITEM_USED } from '../../../events/eventTypes.js';
+
+export const itemSystem = {
+  start() {
+    this.unsubscribe = eventBus.on(ITEM_USED, (item) => {
+      console.log('Item used', item);
+    });
+  },
+  stop() {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+  },
+};

--- a/src/features/combat/systems/magicSystem.js
+++ b/src/features/combat/systems/magicSystem.js
@@ -1,0 +1,14 @@
+import { eventBus } from '../../../events/EventBus.js';
+import { CAST_SPELL } from '../../../events/eventTypes.js';
+
+export const magicSystem = {
+  start() {
+    this.unsubscribe = eventBus.on(CAST_SPELL, (spell) => {
+      console.log('Casting spell', spell);
+    });
+  },
+  stop() {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+  },
+};

--- a/src/features/combat/systems/targetingSystem.js
+++ b/src/features/combat/systems/targetingSystem.js
@@ -1,0 +1,14 @@
+import { eventBus } from '../../../events/EventBus.js';
+import { TARGET_SELECTED } from '../../../events/eventTypes.js';
+
+export const targetingSystem = {
+  start() {
+    this.unsubscribe = eventBus.on(TARGET_SELECTED, (target) => {
+      console.log('Target selected', target);
+    });
+  },
+  stop() {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+  },
+};

--- a/src/features/combat/wizardryCombatFeature.js
+++ b/src/features/combat/wizardryCombatFeature.js
@@ -1,0 +1,11 @@
+import { magicSystem } from './systems/magicSystem.js';
+import { itemSystem } from './systems/itemSystem.js';
+import { targetingSystem } from './systems/targetingSystem.js';
+
+export const WIZARDRY_COMBAT = 'WIZARDRY_COMBAT';
+
+export function registerWizardryCombatFeature(manager) {
+  manager.registerFeature(WIZARDRY_COMBAT, {
+    systems: [magicSystem, itemSystem, targetingSystem],
+  });
+}

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -1,0 +1,17 @@
+import { featureManager } from './FeatureManager.js';
+import { registerWizardryCombatFeature, WIZARDRY_COMBAT } from './combat/wizardryCombatFeature.js';
+
+// Central place to register all features and their initial flags
+const featureFlags = {
+  [WIZARDRY_COMBAT]: true,
+};
+
+registerWizardryCombatFeature(featureManager);
+
+Object.entries(featureFlags).forEach(([id, enabled]) => {
+  if (enabled) {
+    featureManager.enableFeature(id);
+  }
+});
+
+export { featureManager, featureFlags };

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,6 @@
+import './features/index.js';
 import StartGame from './game/main';
 
 document.addEventListener('DOMContentLoaded', () => {
-
     StartGame('game-container');
-
 });


### PR DESCRIPTION
## Summary
- add FeatureManager to handle feature flags and cascading enable/disable
- register wizardry combat feature with related systems
- extend event types and bootstrap features on game start

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c694c6806483278c62b9e90e223522