### PR TITLE
feat: add recursive dungeon generator

### DIFF
--- a/src/features/dungeon/recursiveBacktrackingGenerator.js
+++ b/src/features/dungeon/recursiveBacktrackingGenerator.js
@@ -1,0 +1,37 @@
+export function generateDungeon(width, height) {
+  const mazeWidth = width % 2 === 0 ? width + 1 : width;
+  const mazeHeight = height % 2 === 0 ? height + 1 : height;
+  const grid = Array.from({ length: mazeHeight }, () => Array(mazeWidth).fill(1));
+
+  function shuffle(arr) {
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  }
+
+  function carve(x, y) {
+    grid[y][x] = 0;
+    const directions = shuffle([
+      [1, 0],
+      [-1, 0],
+      [0, 1],
+      [0, -1],
+    ]);
+    for (const [dx, dy] of directions) {
+      const nx = x + dx * 2;
+      const ny = y + dy * 2;
+      if (ny <= 0 || ny >= mazeHeight - 1 || nx <= 0 || nx >= mazeWidth - 1) {
+        continue;
+      }
+      if (grid[ny][nx] === 1) {
+        grid[y + dy][x + dx] = 0;
+        carve(nx, ny);
+      }
+    }
+  }
+
+  carve(1, 1);
+  return grid;
+}

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -42,6 +42,8 @@ export class Preloader extends Scene
         this.load.setPath('assets');
 
         this.load.image('logo', 'logo.png');
+        this.load.image('dungeonFloor', 'images/dungeon/tilesets/floor-tile-1.png');
+        this.load.image('dungeonWall', 'images/dungeon/tilesets/wall-tile-1.png');
     }
 
     create ()

--- a/src/game/states/DungeonExplorationState.js
+++ b/src/game/states/DungeonExplorationState.js
@@ -3,6 +3,7 @@ import { gameStateManager, GameStates } from './GameStateManager';
 import { Entity, PositionComponent, StatsComponent } from '../../ecs';
 import { MeasurementManager } from '../../MeasurementManager';
 import { debugLogManager } from '../../utils/DebugLogManager';
+import { generateDungeon } from '../../features/dungeon/recursiveBacktrackingGenerator.js';
 
 export class DungeonExplorationState extends Scene {
   constructor() {
@@ -18,14 +19,23 @@ export class DungeonExplorationState extends Scene {
       id: this.player.id,
       stats: this.player.getComponent(StatsComponent)
     });
+    const dungeon = generateDungeon(21, 21);
+    const tileSize = 32;
+    const offsetX = (MeasurementManager.screenWidth - dungeon[0].length * tileSize) / 2;
+    const offsetY = (MeasurementManager.screenHeight - dungeon.length * tileSize) / 2;
 
-    const { centerX, centerY } = MeasurementManager;
-
-    this.add.text(centerX, centerY, 'Dungeon Exploration', {
-      fontFamily: 'Arial',
-      fontSize: MeasurementManager.fontSizes.default,
-      color: '#ffffff'
-    }).setOrigin(0.5);
+    for (let y = 0; y < dungeon.length; y++) {
+      for (let x = 0; x < dungeon[0].length; x++) {
+        const texture = dungeon[y][x] === 1 ? 'dungeonWall' : 'dungeonFloor';
+        this.add
+          .image(
+            offsetX + x * tileSize + tileSize / 2,
+            offsetY + y * tileSize + tileSize / 2,
+            texture
+          )
+          .setDisplaySize(tileSize, tileSize);
+      }
+    }
 
     this.input.once('pointerdown', () => {
       debugLogManager.log('Dungeon pointerdown');


### PR DESCRIPTION
## Summary
- generate perfect mazes with recursive backtracking
- preload dungeon floor and wall tiles
- render generated dungeon during exploration state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c698762d7c83279641fe7724f324a0