### PR TITLE
fix: correct asset paths for browser loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="./public/style.css">
     <title>Phaser - Template</title>
 </head>
 
@@ -12,6 +12,6 @@
     <div id="app">
         <div id="game-container"></div>
     </div>
-    <script type="module" src="src/main.js"></script>
+    <script type="module" src="./src/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- point index.html to the public stylesheet using a relative path
- use relative module path for main script to prevent 404 errors

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c699b9797483278e98178fed61c728