### PR TITLE
Fix missing JS extension in startup import

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 import './features/index.js';
-import StartGame from './game/main';
+import StartGame from './game/main.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     StartGame('game-container');


### PR DESCRIPTION
## Summary
- use explicit `.js` extension when importing the game bootstrap to avoid 404 errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c69b51af8c83278d270d0cd990c5b0