### PR TITLE
fix: use CDN Phaser and explicit module extensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <script type="importmap">
     {
         "imports": {
-            "phaser": "./node_modules/phaser/dist/phaser.esm.js"
+            "phaser": "https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js"
         }
     }
     </script>

--- a/src/ecs/index.js
+++ b/src/ecs/index.js
@@ -1,6 +1,6 @@
-export { Entity } from './Entity';
-export { PositionComponent } from './components/PositionComponent';
-export { StatsComponent } from './components/StatsComponent';
-export { RenderComponent } from './components/RenderComponent';
-export { PlayerInputComponent } from './components/PlayerInputComponent';
-export { AIComponent } from './components/AIComponent';
+export { Entity } from './Entity.js';
+export { PositionComponent } from './components/PositionComponent.js';
+export { StatsComponent } from './components/StatsComponent.js';
+export { RenderComponent } from './components/RenderComponent.js';
+export { PlayerInputComponent } from './components/PlayerInputComponent.js';
+export { AIComponent } from './components/AIComponent.js';

--- a/src/game/main.js
+++ b/src/game/main.js
@@ -1,13 +1,13 @@
-import { Boot } from './scenes/Boot';
-import { GameOver } from './scenes/GameOver';
-import { MainMenu } from './scenes/MainMenu';
-import { Preloader } from './scenes/Preloader';
-import { DungeonExplorationState } from './states/DungeonExplorationState';
-import { CombatState } from './states/CombatState';
-import { gameStateManager } from './states/GameStateManager';
+import { Boot } from './scenes/Boot.js';
+import { GameOver } from './scenes/GameOver.js';
+import { MainMenu } from './scenes/MainMenu.js';
+import { Preloader } from './scenes/Preloader.js';
+import { DungeonExplorationState } from './states/DungeonExplorationState.js';
+import { CombatState } from './states/CombatState.js';
+import { gameStateManager } from './states/GameStateManager.js';
 import { AUTO, Game } from 'phaser';
-import { MeasurementManager } from '../MeasurementManager';
-import { debugLogManager } from '../utils/DebugLogManager';
+import { MeasurementManager } from '../MeasurementManager.js';
+import { debugLogManager } from '../utils/DebugLogManager.js';
 
 const config = {
     type: AUTO,

--- a/src/game/scenes/GameOver.js
+++ b/src/game/scenes/GameOver.js
@@ -1,5 +1,5 @@
 import { Scene } from 'phaser';
-import { MeasurementManager } from '../../MeasurementManager';
+import { MeasurementManager } from '../../MeasurementManager.js';
 
 export class GameOver extends Scene
 {

--- a/src/game/scenes/MainMenu.js
+++ b/src/game/scenes/MainMenu.js
@@ -1,6 +1,6 @@
 import { Scene } from 'phaser';
-import { gameStateManager, GameStates } from '../states/GameStateManager';
-import { MeasurementManager } from '../../MeasurementManager';
+import { gameStateManager, GameStates } from '../states/GameStateManager.js';
+import { MeasurementManager } from '../../MeasurementManager.js';
 
 export class MainMenu extends Scene
 {

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -1,5 +1,5 @@
 import { Scene } from 'phaser';
-import { MeasurementManager } from '../../MeasurementManager';
+import { MeasurementManager } from '../../MeasurementManager.js';
 
 export class Preloader extends Scene
 {

--- a/src/game/states/CombatState.js
+++ b/src/game/states/CombatState.js
@@ -1,7 +1,7 @@
 import { Scene } from 'phaser';
-import { gameStateManager, GameStates } from './GameStateManager';
-import { MeasurementManager } from '../../MeasurementManager';
-import { debugLogManager } from '../../utils/DebugLogManager';
+import { gameStateManager, GameStates } from './GameStateManager.js';
+import { MeasurementManager } from '../../MeasurementManager.js';
+import { debugLogManager } from '../../utils/DebugLogManager.js';
 
 export class CombatState extends Scene {
   constructor() {

--- a/src/game/states/DungeonExplorationState.js
+++ b/src/game/states/DungeonExplorationState.js
@@ -1,8 +1,8 @@
 import { Scene } from 'phaser';
-import { gameStateManager, GameStates } from './GameStateManager';
-import { Entity, PositionComponent, StatsComponent } from '../../ecs';
-import { MeasurementManager } from '../../MeasurementManager';
-import { debugLogManager } from '../../utils/DebugLogManager';
+import { gameStateManager, GameStates } from './GameStateManager.js';
+import { Entity, PositionComponent, StatsComponent } from '../../ecs/index.js';
+import { MeasurementManager } from '../../MeasurementManager.js';
+import { debugLogManager } from '../../utils/DebugLogManager.js';
 import { generateDungeon } from '../../features/dungeon/recursiveBacktrackingGenerator.js';
 
 export class DungeonExplorationState extends Scene {

--- a/src/game/states/GameStateManager.js
+++ b/src/game/states/GameStateManager.js
@@ -1,4 +1,4 @@
-import { debugLogManager } from '../../utils/DebugLogManager';
+import { debugLogManager } from '../../utils/DebugLogManager.js';
 
 export const GameStates = {
   DUNGEON: 'DungeonExplorationState',


### PR DESCRIPTION
## Summary
- load Phaser via CDN to avoid missing node_modules in production
- add `.js` extensions to all internal module imports and exports so the browser can resolve them directly

## Testing
- `npm install`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6b3ad27148327beb1cca63b0ce184