### PR TITLE
fix: import Phaser Scale module to avoid runtime error

### DIFF
--- a/src/game/main.js
+++ b/src/game/main.js
@@ -5,7 +5,7 @@ import { Preloader } from './scenes/Preloader.js';
 import { DungeonExplorationState } from './states/DungeonExplorationState.js';
 import { CombatState } from './states/CombatState.js';
 import { gameStateManager } from './states/GameStateManager.js';
-import { AUTO, Game } from 'phaser';
+import { AUTO, Game, Scale } from 'phaser';
 import { MeasurementManager } from '../MeasurementManager.js';
 import { debugLogManager } from '../utils/DebugLogManager.js';
 
@@ -16,8 +16,8 @@ const config = {
     parent: 'game-container',
     backgroundColor: '#028af8',
     scale: {
-        mode: Phaser.Scale.FIT,
-        autoCenter: Phaser.Scale.CENTER_BOTH
+        mode: Scale.FIT,
+        autoCenter: Scale.CENTER_BOTH
     },
     scene: [
         Boot,


### PR DESCRIPTION
## Summary
- import `Scale` from `phaser` and use it directly to avoid `Phaser` being undefined

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build-nolog`


------
https://chatgpt.com/codex/tasks/task_e_68c6b6ed04f48327bb1b36bd4940754e