### PR TITLE
feat: add party movement, FOV, and turn management

### DIFF
--- a/src/events/eventTypes.js
+++ b/src/events/eventTypes.js
@@ -6,3 +6,5 @@ export const MOVE_REQUEST = 'MOVE_REQUEST';
 export const CAST_SPELL = 'CAST_SPELL';
 export const ITEM_USED = 'ITEM_USED';
 export const TARGET_SELECTED = 'TARGET_SELECTED';
+export const MONSTERS_TURN_START = 'MONSTERS_TURN_START';
+export const MONSTERS_TURN_END = 'MONSTERS_TURN_END';

--- a/src/features/fov/index.js
+++ b/src/features/fov/index.js
@@ -1,0 +1,1 @@
+export { raycastFOV } from './raycasting.js';

--- a/src/features/fov/raycasting.js
+++ b/src/features/fov/raycasting.js
@@ -1,0 +1,23 @@
+import { bresenhamLine } from '../../utils/bresenham.js';
+
+export const raycastFOV = (map, origin, radius) => {
+  const visible = new Set();
+  const { x: ox, y: oy } = origin;
+  const height = map.length;
+  const width = map[0].length;
+
+  for (let y = oy - radius; y <= oy + radius; y++) {
+    for (let x = ox - radius; x <= ox + radius; x++) {
+      if (x < 0 || y < 0 || x >= width || y >= height) continue;
+      const line = bresenhamLine(ox, oy, x, y);
+      for (const [lx, ly] of line) {
+        visible.add(`${lx},${ly}`);
+        if (map[ly][lx] === 1 && !(lx === x && ly === y)) {
+          break;
+        }
+      }
+    }
+  }
+
+  return visible;
+};

--- a/src/game/states/DungeonExplorationState.js
+++ b/src/game/states/DungeonExplorationState.js
@@ -1,9 +1,14 @@
 import { Scene } from 'phaser';
-import { gameStateManager, GameStates } from './GameStateManager.js';
+import { GameStates } from './GameStateManager.js';
 import { Entity, PositionComponent, StatsComponent } from '../../ecs/index.js';
 import { MeasurementManager } from '../../MeasurementManager.js';
 import { debugLogManager } from '../../utils/DebugLogManager.js';
 import { generateDungeon } from '../../features/dungeon/recursiveBacktrackingGenerator.js';
+import { eventBus } from '../../events/EventBus.js';
+import { PLAYER_MOVED } from '../../events/eventTypes.js';
+import { turnManager } from '../../systems/turnManager.js';
+import { aiSystem } from '../../systems/aiSystem.js';
+import { raycastFOV } from '../../features/fov/index.js';
 
 export class DungeonExplorationState extends Scene {
   constructor() {
@@ -12,34 +17,85 @@ export class DungeonExplorationState extends Scene {
 
   create() {
     debugLogManager.log('Dungeon exploration state entered');
-    this.player = new Entity('player')
-      .addComponent(new PositionComponent(0, 0))
-      .addComponent(new StatsComponent(100, 10));
-    debugLogManager.log('Player entity created', {
-      id: this.player.id,
-      stats: this.player.getComponent(StatsComponent)
-    });
-    const dungeon = generateDungeon(21, 21);
-    const tileSize = 32;
-    const offsetX = (MeasurementManager.screenWidth - dungeon[0].length * tileSize) / 2;
-    const offsetY = (MeasurementManager.screenHeight - dungeon.length * tileSize) / 2;
 
-    for (let y = 0; y < dungeon.length; y++) {
-      for (let x = 0; x < dungeon[0].length; x++) {
-        const texture = dungeon[y][x] === 1 ? 'dungeonWall' : 'dungeonFloor';
+    this.bus = eventBus;
+    this.turn = turnManager(this.bus);
+    this.turn.init();
+    aiSystem(this.bus).init();
+
+    this.dungeon = generateDungeon(21, 21);
+    this.tileSize = 32;
+    this.offsetX =
+      (MeasurementManager.screenWidth - this.dungeon[0].length * this.tileSize) / 2;
+    this.offsetY =
+      (MeasurementManager.screenHeight - this.dungeon.length * this.tileSize) / 2;
+
+    this.player = new Entity('player')
+      .addComponent(new PositionComponent(1, 1))
+      .addComponent(new StatsComponent(100, 10));
+
+    this.playerSprite = this.add.rectangle(
+      this.offsetX + this.tileSize / 2,
+      this.offsetY + this.tileSize / 2,
+      this.tileSize * 0.8,
+      this.tileSize * 0.8,
+      0x00ff00
+    );
+
+    for (let y = 0; y < this.dungeon.length; y++) {
+      for (let x = 0; x < this.dungeon[0].length; x++) {
+        const texture = this.dungeon[y][x] === 1 ? 'dungeonWall' : 'dungeonFloor';
         this.add
           .image(
-            offsetX + x * tileSize + tileSize / 2,
-            offsetY + y * tileSize + tileSize / 2,
+            this.offsetX + x * this.tileSize + this.tileSize / 2,
+            this.offsetY + y * this.tileSize + this.tileSize / 2,
             texture
           )
-          .setDisplaySize(tileSize, tileSize);
+          .setDisplaySize(this.tileSize, this.tileSize);
       }
     }
 
-    this.input.once('pointerdown', () => {
-      debugLogManager.log('Dungeon pointerdown');
-      gameStateManager.changeState(GameStates.COMBAT);
+    this.input.keyboard.on('keydown', (event) => {
+      if (!this.turn.canPlayerAct()) return;
+      const pos = this.player.getComponent(PositionComponent);
+      let dx = 0;
+      let dy = 0;
+      switch (event.key) {
+        case 'ArrowUp':
+          dy = -1;
+          break;
+        case 'ArrowDown':
+          dy = 1;
+          break;
+        case 'ArrowLeft':
+          dx = -1;
+          break;
+        case 'ArrowRight':
+          dx = 1;
+          break;
+        default:
+          return;
+      }
+      const nx = pos.x + dx;
+      const ny = pos.y + dy;
+      if (this.dungeon[ny]?.[nx] !== 1) {
+        pos.x = nx;
+        pos.y = ny;
+        this.playerSprite.setPosition(
+          this.offsetX + nx * this.tileSize + this.tileSize / 2,
+          this.offsetY + ny * this.tileSize + this.tileSize / 2
+        );
+        this.bus.emit(PLAYER_MOVED, { id: this.player.id, x: nx, y: ny });
+        this.updateFOV();
+      }
     });
+
+    this.updateFOV();
+  }
+
+  updateFOV() {
+    const pos = this.player.getComponent(PositionComponent);
+    const tiles = raycastFOV(this.dungeon, { x: pos.x, y: pos.y }, 8);
+    debugLogManager.log('FOV updated', { visibleTiles: tiles.size });
   }
 }

--- a/src/systems/aiSystem.js
+++ b/src/systems/aiSystem.js
@@ -1,8 +1,15 @@
 // AI decision making placeholder
+import { MONSTERS_TURN_START, MONSTERS_TURN_END } from '../events/eventTypes.js';
+
 export const aiSystem = (bus, state) => {
   const id = 'ai';
 
-  const init = () => {};
+  const init = () => {
+    bus.on(MONSTERS_TURN_START, () => {
+      // Placeholder for simultaneous monster actions
+      bus.emit(MONSTERS_TURN_END);
+    });
+  };
 
   const update = () => {};
 

--- a/src/systems/turnManager.js
+++ b/src/systems/turnManager.js
@@ -1,0 +1,20 @@
+import { PLAYER_MOVED, MONSTERS_TURN_START, MONSTERS_TURN_END } from '../events/eventTypes.js';
+
+export const turnManager = (bus) => {
+  const id = 'turn-manager';
+  let playerTurn = true;
+
+  const init = () => {
+    bus.on(PLAYER_MOVED, () => {
+      playerTurn = false;
+      bus.emit(MONSTERS_TURN_START);
+    });
+    bus.on(MONSTERS_TURN_END, () => {
+      playerTurn = true;
+    });
+  };
+
+  const canPlayerAct = () => playerTurn;
+
+  return { id, init, canPlayerAct };
+};

--- a/src/utils/bresenham.js
+++ b/src/utils/bresenham.js
@@ -1,0 +1,26 @@
+export const bresenhamLine = (x0, y0, x1, y1) => {
+  const points = [];
+  let dx = Math.abs(x1 - x0);
+  let dy = -Math.abs(y1 - y0);
+  let sx = x0 < x1 ? 1 : -1;
+  let sy = y0 < y1 ? 1 : -1;
+  let err = dx + dy;
+  let x = x0;
+  let y = y0;
+
+  while (true) {
+    points.push([x, y]);
+    if (x === x1 && y === y1) break;
+    const e2 = 2 * err;
+    if (e2 >= dy) {
+      err += dy;
+      x += sx;
+    }
+    if (e2 <= dx) {
+      err += dx;
+      y += sy;
+    }
+  }
+
+  return points;
+};


### PR DESCRIPTION
## Summary
- move the party with arrow keys on a grid
- compute player field of view using raycasting
- manage we-go turns between player and monsters

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c6bce5cf7883279dc792bf4aa16ec2