### PR TITLE
Implement combat transition and UI

### DIFF
--- a/src/features/combat/data/enemies.js
+++ b/src/features/combat/data/enemies.js
@@ -1,0 +1,32 @@
+export const DEFAULT_COMBAT_BACKGROUND = 'combatBackgroundForest';
+
+const ENEMIES = [
+  {
+    id: 'crypt-zombie',
+    name: 'Crypt Zombie',
+    level: 3,
+    texture: 'monsterZombie',
+    description: 'A shambling corpse animated by dungeon miasma.',
+    maxHp: 90,
+    currentHp: 90,
+    backgroundKey: DEFAULT_COMBAT_BACKGROUND,
+  },
+];
+
+function cloneEnemy(enemy) {
+  return { ...enemy };
+}
+
+export function getRandomEnemy(randomFn = Math.random) {
+  if (ENEMIES.length === 0) {
+    throw new Error('No enemies configured for encounters');
+  }
+
+  const clampedRandom = Math.min(Math.max(randomFn(), 0), 0.9999999999);
+  const index = Math.floor(clampedRandom * ENEMIES.length);
+  return cloneEnemy(ENEMIES[index]);
+}
+
+export function getDefaultEnemy() {
+  return cloneEnemy(ENEMIES[0]);
+}

--- a/src/features/combat/data/partyRoster.js
+++ b/src/features/combat/data/partyRoster.js
@@ -1,0 +1,46 @@
+const BASE_PARTY = [
+  {
+    id: 'aria',
+    name: 'Aria the Bold',
+    role: 'Frontline Warrior',
+    level: 4,
+    maxHp: 120,
+    currentHp: 120,
+    maxMp: 8,
+    currentMp: 8,
+  },
+  {
+    id: 'brann',
+    name: 'Brann Wildstep',
+    role: 'Scout Ranger',
+    level: 4,
+    maxHp: 95,
+    currentHp: 95,
+    maxMp: 18,
+    currentMp: 18,
+  },
+  {
+    id: 'celine',
+    name: 'Celine Ashweaver',
+    role: 'Arcane Scholar',
+    level: 4,
+    maxHp: 70,
+    currentHp: 70,
+    maxMp: 52,
+    currentMp: 52,
+  },
+  {
+    id: 'dorian',
+    name: 'Dorian Lightbearer',
+    role: 'Cleric Adept',
+    level: 4,
+    maxHp: 88,
+    currentHp: 88,
+    maxMp: 44,
+    currentMp: 44,
+  },
+];
+
+export function createBasePartyRoster() {
+  return BASE_PARTY.map((member) => ({ ...member }));
+}

--- a/src/features/combat/encounters/RandomEncounterController.js
+++ b/src/features/combat/encounters/RandomEncounterController.js
@@ -1,0 +1,83 @@
+import { PLAYER_MOVED } from '../../../events/eventTypes.js';
+import { debugLogManager } from '../../../utils/DebugLogManager.js';
+
+const DEFAULT_OPTIONS = {
+  encounterChance: 0.18,
+  minimumSteps: 3,
+};
+
+export class RandomEncounterController {
+  constructor({ bus, onEncounter, encounterChance, minimumSteps } = {}) {
+    if (!bus) {
+      throw new Error('RandomEncounterController requires an event bus');
+    }
+
+    this.bus = bus;
+    this.onEncounter = onEncounter;
+
+    const options = {
+      ...DEFAULT_OPTIONS,
+      ...(Number.isFinite(encounterChance) ? { encounterChance } : {}),
+      ...(Number.isFinite(minimumSteps) ? { minimumSteps: Math.max(0, minimumSteps) } : {}),
+    };
+
+    this.encounterChance = options.encounterChance;
+    this.minimumSteps = options.minimumSteps;
+    this.stepsSinceLastEncounter = 0;
+    this.active = false;
+    this.locked = false;
+    this.unsubscribe = null;
+
+    this.handlePlayerMoved = this.handlePlayerMoved.bind(this);
+  }
+
+  start() {
+    if (this.active) {
+      return;
+    }
+
+    this.unsubscribe = this.bus.on(PLAYER_MOVED, this.handlePlayerMoved);
+    this.active = true;
+    debugLogManager.log('Random encounter controller started', {
+      encounterChance: this.encounterChance,
+      minimumSteps: this.minimumSteps,
+    });
+  }
+
+  stop() {
+    if (!this.active) {
+      return;
+    }
+
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.active = false;
+    this.locked = false;
+    this.stepsSinceLastEncounter = 0;
+    debugLogManager.log('Random encounter controller stopped');
+  }
+
+  destroy() {
+    this.stop();
+    this.onEncounter = null;
+  }
+
+  handlePlayerMoved() {
+    if (!this.active || this.locked) {
+      return;
+    }
+
+    this.stepsSinceLastEncounter += 1;
+
+    if (this.stepsSinceLastEncounter < this.minimumSteps) {
+      return;
+    }
+
+    if (Math.random() <= this.encounterChance) {
+      this.locked = true;
+      this.stepsSinceLastEncounter = 0;
+      debugLogManager.log('Random encounter triggered');
+      this.onEncounter?.();
+    }
+  }
+}

--- a/src/features/combat/ui/CombatUI.js
+++ b/src/features/combat/ui/CombatUI.js
@@ -1,0 +1,302 @@
+import { MeasurementManager } from '../../../MeasurementManager.js';
+import { DEFAULT_COMBAT_BACKGROUND } from '../data/enemies.js';
+
+const UI_COLORS = {
+  overlay: 0x000000,
+  panel: 0x0b1623,
+  panelStroke: 0x3d6df2,
+  row: 0x112235,
+  rowStroke: 0x1c3f70,
+  rowHover: 0x193452,
+  enemyFrame: 0x0d1422,
+  enemyFrameStroke: 0x4aa3ff,
+};
+
+const UI_ALPHA = {
+  overlay: 0.35,
+  panel: 0.78,
+  row: 0.92,
+  enemyFrame: 0.68,
+};
+
+const COMMANDS = [
+  { id: 'attack', label: 'Attack' },
+  { id: 'defend', label: 'Defend' },
+  { id: 'magic', label: 'Magic' },
+  { id: 'item', label: 'Item' },
+];
+
+export class CombatUI {
+  constructor(scene, { onCommandSelected } = {}) {
+    this.scene = scene;
+    this.onCommandSelected = onCommandSelected;
+    this.objects = [];
+    this.commandButtons = [];
+  }
+
+  render({ party = [], enemy = {}, backgroundKey = DEFAULT_COMBAT_BACKGROUND, hint } = {}) {
+    this.clear();
+
+    this.drawBackground(backgroundKey);
+    this.drawEnemy(enemy);
+    this.drawPartyPanel(party);
+    this.drawCommandPanel();
+
+    if (hint) {
+      this.drawHint(hint);
+    }
+  }
+
+  clear() {
+    this.commandButtons.forEach(({ button }) => {
+      button.removeAllListeners?.();
+    });
+
+    this.objects.forEach((obj) => obj.destroy());
+    this.objects.length = 0;
+    this.commandButtons.length = 0;
+  }
+
+  destroy() {
+    this.clear();
+    this.onCommandSelected = null;
+  }
+
+  register(gameObject) {
+    if (gameObject.setScrollFactor) {
+      gameObject.setScrollFactor(0);
+    }
+    this.objects.push(gameObject);
+    return gameObject;
+  }
+
+  drawBackground(backgroundKey) {
+    const { centerX, centerY, screenWidth, screenHeight } = MeasurementManager;
+
+    if (backgroundKey && this.scene.textures.exists(backgroundKey)) {
+      const background = this.register(
+        this.scene.add.image(centerX, centerY, backgroundKey)
+      );
+      background.setDisplaySize(screenWidth, screenHeight);
+      background.setAlpha(0.9);
+      background.setDepth(-2);
+    }
+
+    const overlay = this.register(
+      this.scene.add.rectangle(centerX, centerY, screenWidth, screenHeight, UI_COLORS.overlay, UI_ALPHA.overlay)
+    );
+    overlay.setDepth(-1);
+  }
+
+  drawEnemy(enemy) {
+    const { centerX, centerY } = MeasurementManager;
+    const frameWidth = 420;
+    const frameHeight = 320;
+    const frameY = centerY - 170;
+
+    const frame = this.register(
+      this.scene.add.rectangle(centerX, frameY, frameWidth, frameHeight, UI_COLORS.enemyFrame, UI_ALPHA.enemyFrame)
+    );
+    frame.setStrokeStyle(2, UI_COLORS.enemyFrameStroke);
+
+    const frameTop = frameY - frameHeight / 2;
+    const frameBottom = frameY + frameHeight / 2;
+
+    const title = this.register(
+      this.scene.add.text(centerX, frameTop + 18, enemy.name ?? 'Unknown Foe', {
+        fontFamily: 'Arial Black',
+        fontSize: '28px',
+        color: '#ffffff',
+        align: 'center',
+      })
+    );
+    title.setOrigin(0.5, 0);
+
+    if (enemy.level) {
+      const levelBadge = this.register(
+        this.scene.add.text(frame.x + frameWidth / 2 - 16, frameTop + 18, `Lv ${enemy.level}`, {
+          fontFamily: 'Arial',
+          fontSize: '18px',
+          color: '#8cb1ff',
+        })
+      );
+      levelBadge.setOrigin(1, 0);
+    }
+
+    if (enemy.texture && this.scene.textures.exists(enemy.texture)) {
+      const sprite = this.register(
+        this.scene.add.image(centerX, frameBottom - 24, enemy.texture)
+      );
+      sprite.setOrigin(0.5, 1);
+      const maxWidth = frameWidth - 80;
+      const maxHeight = frameHeight - 96;
+      const baseWidth = sprite.width || maxWidth;
+      const baseHeight = sprite.height || maxHeight;
+      const scale = Math.min(maxWidth / baseWidth, maxHeight / baseHeight);
+      if (Number.isFinite(scale) && scale > 0) {
+        sprite.setScale(scale);
+      } else {
+        sprite.setDisplaySize(maxWidth, maxHeight);
+      }
+    } else {
+      const placeholder = this.register(
+        this.scene.add.rectangle(centerX, frameBottom - 60, frameWidth - 100, frameHeight - 140, UI_COLORS.row, UI_ALPHA.row)
+      );
+      placeholder.setOrigin(0.5, 1);
+      placeholder.setStrokeStyle(2, UI_COLORS.rowStroke);
+
+      const placeholderText = this.register(
+        this.scene.add.text(centerX, frameBottom - 140, 'No enemy art', {
+          fontFamily: 'Arial',
+          fontSize: '20px',
+          color: '#d0d6ff',
+        })
+      );
+      placeholderText.setOrigin(0.5, 0.5);
+    }
+
+    if (enemy.description) {
+      const description = this.register(
+        this.scene.add.text(centerX, frameBottom + 18, enemy.description, {
+          fontFamily: 'Arial',
+          fontSize: '18px',
+          color: '#d0d6ff',
+          align: 'center',
+          wordWrap: { width: frameWidth + 160 },
+        })
+      );
+      description.setOrigin(0.5, 0);
+      description.setAlpha(0.92);
+    }
+  }
+
+  drawPartyPanel(party) {
+    const panelPadding = 14;
+    const rowHeight = 60;
+    const rowGap = 10;
+    const width = 360;
+    const rows = Math.max(party.length, 1);
+    const height = panelPadding * 2 + rows * rowHeight + (rows - 1) * rowGap;
+    const startX = 48;
+    const startY = MeasurementManager.screenHeight - height - 48;
+
+    const panel = this.register(
+      this.scene.add.rectangle(startX, startY, width, height, UI_COLORS.panel, UI_ALPHA.panel)
+    );
+    panel.setOrigin(0, 0);
+    panel.setStrokeStyle(2, UI_COLORS.panelStroke);
+
+    party.forEach((member, index) => {
+      const rowY = startY + panelPadding + index * (rowHeight + rowGap);
+
+      const row = this.register(
+        this.scene.add.rectangle(startX + panelPadding, rowY, width - panelPadding * 2, rowHeight, UI_COLORS.row, UI_ALPHA.row)
+      );
+      row.setOrigin(0, 0);
+      row.setStrokeStyle(2, UI_COLORS.rowStroke);
+
+      const nameText = this.register(
+        this.scene.add.text(startX + panelPadding + 12, rowY + 6, member.name ?? 'Unknown', {
+          fontFamily: 'Arial',
+          fontSize: '20px',
+          color: '#ffffff',
+        })
+      );
+      nameText.setOrigin(0, 0);
+
+      const roleText = this.register(
+        this.scene.add.text(startX + panelPadding + 12, rowY + 32, `Lv ${member.level ?? 1} · ${member.role ?? 'Adventurer'}`, {
+          fontFamily: 'Arial',
+          fontSize: '16px',
+          color: '#8cb1ff',
+        })
+      );
+      roleText.setOrigin(0, 0);
+
+      const hpText = this.register(
+        this.scene.add.text(startX + width - panelPadding - 12, rowY + 10, `HP ${member.currentHp ?? 0}/${member.maxHp ?? 0}`, {
+          fontFamily: 'Courier',
+          fontSize: '18px',
+          color: '#7ce8ff',
+        })
+      );
+      hpText.setOrigin(1, 0);
+
+      const mpText = this.register(
+        this.scene.add.text(startX + width - panelPadding - 12, rowY + 32, `MP ${member.currentMp ?? 0}/${member.maxMp ?? 0}`, {
+          fontFamily: 'Courier',
+          fontSize: '16px',
+          color: '#caa4ff',
+        })
+      );
+      mpText.setOrigin(1, 0);
+    });
+  }
+
+  drawCommandPanel() {
+    const padding = 12;
+    const rowHeight = 56;
+    const rowGap = 10;
+    const width = 240;
+    const rows = COMMANDS.length;
+    const height = padding * 2 + rows * rowHeight + (rows - 1) * rowGap;
+    const startX = MeasurementManager.screenWidth - width - 48;
+    const startY = MeasurementManager.screenHeight - height - 48;
+
+    const panel = this.register(
+      this.scene.add.rectangle(startX, startY, width, height, UI_COLORS.panel, UI_ALPHA.panel)
+    );
+    panel.setOrigin(0, 0);
+    panel.setStrokeStyle(2, UI_COLORS.panelStroke);
+
+    COMMANDS.forEach((command, index) => {
+      const rowY = startY + padding + index * (rowHeight + rowGap);
+      this.createCommandButton(startX + padding, rowY, width - padding * 2, rowHeight, command);
+    });
+  }
+
+  createCommandButton(x, y, width, height, command) {
+    const button = this.register(
+      this.scene.add.rectangle(x, y, width, height, UI_COLORS.row, UI_ALPHA.row)
+    );
+    button.setOrigin(0, 0);
+    button.setStrokeStyle(2, UI_COLORS.rowStroke);
+    button.setInteractive({ useHandCursor: true });
+
+    button.on('pointerover', () => {
+      button.setFillStyle(UI_COLORS.rowHover, 1);
+    });
+
+    button.on('pointerout', () => {
+      button.setFillStyle(UI_COLORS.row, UI_ALPHA.row);
+    });
+
+    button.on('pointerdown', () => {
+      this.onCommandSelected?.(command.id);
+    });
+
+    const label = this.register(
+      this.scene.add.text(x + width / 2, y + height / 2, command.label, {
+        fontFamily: 'Arial',
+        fontSize: '20px',
+        color: '#ffffff',
+      })
+    );
+    label.setOrigin(0.5, 0.5);
+
+    this.commandButtons.push({ button, command });
+  }
+
+  drawHint(hint) {
+    const hintText = this.register(
+      this.scene.add.text(MeasurementManager.centerX, MeasurementManager.screenHeight - 16, hint, {
+        fontFamily: 'Arial',
+        fontSize: '16px',
+        color: '#d0d6ff',
+        align: 'center',
+      })
+    );
+    hintText.setOrigin(0.5, 1);
+    hintText.setAlpha(0.85);
+  }
+}

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -45,6 +45,8 @@ export class Preloader extends Scene
         this.load.image('dungeonFloor', 'images/dungeon/tilesets/floor-tile-1.png');
         this.load.image('dungeonWall', 'images/dungeon/tilesets/wall-tile-1.png');
         this.load.image('playerWarrior', 'images/characters/unit/warrior.png');
+        this.load.image('combatBackgroundForest', 'images/battle/backgrounds/battle-stage-cursed-forest.png');
+        this.load.image('monsterZombie', 'images/characters/monsters/zombie.png');
     }
 
     create ()

--- a/src/game/states/CombatState.js
+++ b/src/game/states/CombatState.js
@@ -1,26 +1,107 @@
 import { Scene } from 'phaser';
 import { gameStateManager, GameStates } from './GameStateManager.js';
-import { MeasurementManager } from '../../MeasurementManager.js';
 import { debugLogManager } from '../../utils/DebugLogManager.js';
+import { CombatUI } from '../../features/combat/ui/CombatUI.js';
+import { createBasePartyRoster } from '../../features/combat/data/partyRoster.js';
+import { DEFAULT_COMBAT_BACKGROUND, getDefaultEnemy } from '../../features/combat/data/enemies.js';
 
 export class CombatState extends Scene {
   constructor() {
     super(GameStates.COMBAT);
   }
 
+  init(data) {
+    this.encounterData = data;
+  }
+
   create() {
-    debugLogManager.log('Combat state entered');
-    const { centerX, centerY } = MeasurementManager;
-
-    this.add.text(centerX, centerY, 'Combat', {
-      fontFamily: 'Arial',
-      fontSize: MeasurementManager.fontSizes.default,
-      color: '#ffffff'
-    }).setOrigin(0.5);
-
-    this.input.once('pointerdown', () => {
-      debugLogManager.log('Combat pointerdown');
-      gameStateManager.changeState(GameStates.DUNGEON);
+    debugLogManager.log('Combat state entered', {
+      encounterType: this.encounterData?.encounterType ?? 'UNKNOWN',
     });
+
+    this.cameras.main.setBackgroundColor('#050816');
+
+    const preparedEncounter = this.prepareEncounterData(this.encounterData);
+
+    this.combatUI = new CombatUI(this, {
+      onCommandSelected: (command) => this.handleCommandSelection(command),
+    });
+
+    this.combatUI.render({
+      party: preparedEncounter.party,
+      enemy: preparedEncounter.enemy,
+      backgroundKey: preparedEncounter.backgroundKey,
+      hint: 'Press ESC to return to exploration',
+    });
+
+    this.registerInputHandlers();
+  }
+
+  prepareEncounterData(data = {}) {
+    const enemy = this.normalizeEnemyData(data.enemy);
+    return {
+      party: this.normalizePartyData(data.party),
+      enemy,
+      backgroundKey: data.backgroundKey ?? enemy.backgroundKey ?? DEFAULT_COMBAT_BACKGROUND,
+    };
+  }
+
+  normalizePartyData(partyData) {
+    const source = Array.isArray(partyData) && partyData.length > 0
+      ? partyData
+      : createBasePartyRoster();
+
+    return source.map((member) => {
+      const maxHp = this.safeNumber(member.maxHp ?? member.hp ?? member.currentHp, 0);
+      const currentHp = this.safeNumber(member.currentHp ?? member.hp ?? maxHp, maxHp);
+      const maxMp = this.safeNumber(member.maxMp ?? member.mp ?? member.currentMp, 0);
+      const currentMp = this.safeNumber(member.currentMp ?? member.mp ?? maxMp, maxMp);
+
+      return {
+        ...member,
+        level: member.level ?? 1,
+        role: member.role ?? 'Adventurer',
+        maxHp,
+        currentHp,
+        maxMp,
+        currentMp,
+      };
+    });
+  }
+
+  normalizeEnemyData(enemyData) {
+    const enemy = enemyData ? { ...enemyData } : getDefaultEnemy();
+    enemy.maxHp = this.safeNumber(enemy.maxHp ?? enemy.currentHp, 0);
+    enemy.currentHp = this.safeNumber(enemy.currentHp ?? enemy.maxHp, enemy.maxHp);
+    enemy.level = enemy.level ?? 1;
+    return enemy;
+  }
+
+  safeNumber(value, fallback) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+
+  registerInputHandlers() {
+    this.input.keyboard.on('keydown-ESC', this.handleEscape, this);
+
+    const teardown = () => {
+      this.input.keyboard?.off('keydown-ESC', this.handleEscape, this);
+      this.combatUI?.destroy();
+      this.combatUI = null;
+      this.encounterData = null;
+    };
+
+    this.events.once('shutdown', teardown);
+    this.events.once('destroy', teardown);
+  }
+
+  handleCommandSelection(command) {
+    debugLogManager.log('Combat command selected', { command });
+  }
+
+  handleEscape() {
+    debugLogManager.log('Exit combat requested');
+    gameStateManager.changeState(GameStates.DUNGEON);
   }
 }

--- a/src/game/states/DungeonExplorationState.js
+++ b/src/game/states/DungeonExplorationState.js
@@ -1,5 +1,5 @@
 import { Scene } from 'phaser';
-import { GameStates } from './GameStateManager.js';
+import { gameStateManager, GameStates } from './GameStateManager.js';
 import { Entity, PositionComponent, StatsComponent } from '../../ecs/index.js';
 import { MeasurementManager } from '../../MeasurementManager.js';
 import { debugLogManager } from '../../utils/DebugLogManager.js';
@@ -9,6 +9,9 @@ import { PLAYER_MOVED } from '../../events/eventTypes.js';
 import { turnManager } from '../../systems/turnManager.js';
 import { aiSystem } from '../../systems/aiSystem.js';
 import { raycastFOV } from '../../features/fov/index.js';
+import { RandomEncounterController } from '../../features/combat/encounters/RandomEncounterController.js';
+import { createBasePartyRoster } from '../../features/combat/data/partyRoster.js';
+import { DEFAULT_COMBAT_BACKGROUND, getRandomEnemy } from '../../features/combat/data/enemies.js';
 
 export class DungeonExplorationState extends Scene {
   constructor() {
@@ -21,9 +24,11 @@ export class DungeonExplorationState extends Scene {
     this.initializeSystems();
     this.generateDungeonLayout();
     this.createDungeonTiles();
+    this.partyRoster = createBasePartyRoster();
     this.createPlayer();
     this.setupCamera();
     this.setupInputHandlers();
+    this.initializeEncounterSystem();
 
     this.updateFOV();
   }
@@ -59,9 +64,10 @@ export class DungeonExplorationState extends Scene {
 
   createPlayer() {
     const spawnTile = this.findSpawnTile();
+    const leader = this.partyRoster[0];
     this.player = new Entity('player')
       .addComponent(new PositionComponent(spawnTile.x, spawnTile.y))
-      .addComponent(new StatsComponent(100, 10));
+      .addComponent(new StatsComponent(leader.currentHp, leader.currentMp));
 
     this.playerSprite = this.add
       .sprite(0, 0, 'playerWarrior')
@@ -69,6 +75,59 @@ export class DungeonExplorationState extends Scene {
       .setDepth(1);
 
     this.updatePlayerSpritePosition();
+  }
+
+  initializeEncounterSystem() {
+    this.randomEncounterController = new RandomEncounterController({
+      bus: this.bus,
+      encounterChance: 0.2,
+      minimumSteps: 4,
+      onEncounter: () => this.startCombatEncounter(),
+    });
+
+    this.randomEncounterController.start();
+
+    const teardown = () => {
+      this.randomEncounterController?.destroy();
+      this.randomEncounterController = null;
+    };
+
+    this.events.once('shutdown', teardown);
+    this.events.once('destroy', teardown);
+  }
+
+  startCombatEncounter() {
+    this.randomEncounterController?.stop();
+    const encounterData = this.createRandomEncounter();
+    debugLogManager.log('Encounter starting', {
+      enemy: encounterData.enemy.id,
+      background: encounterData.backgroundKey,
+    });
+    gameStateManager.changeState(GameStates.COMBAT, encounterData);
+  }
+
+  createRandomEncounter() {
+    return {
+      encounterType: 'RANDOM',
+      party: this.buildPartySnapshot(),
+      enemy: getRandomEnemy(),
+      backgroundKey: DEFAULT_COMBAT_BACKGROUND,
+    };
+  }
+
+  buildPartySnapshot() {
+    return this.partyRoster.map((member, index) => {
+      if (index === 0) {
+        const stats = this.player.getComponent(StatsComponent);
+        return {
+          ...member,
+          currentHp: stats.hp,
+          currentMp: stats.mp,
+        };
+      }
+
+      return { ...member };
+    });
   }
 
   findSpawnTile() {

--- a/src/game/states/GameStateManager.js
+++ b/src/game/states/GameStateManager.js
@@ -11,7 +11,7 @@ class GameStateManager {
     this.currentState = null;
   }
 
-  changeState(stateKey) {
+  changeState(stateKey, data) {
     if (!this.game) {
       throw new Error('GameStateManager not initialized');
     }
@@ -20,7 +20,7 @@ class GameStateManager {
       to: stateKey
     });
     this.currentState = stateKey;
-    this.game.scene.start(stateKey);
+    this.game.scene.start(stateKey, data);
   }
 }
 


### PR DESCRIPTION
## Summary
- add modular encounter data and a random encounter controller so dungeon exploration can hand off to combat scenes with party snapshots
- overhaul the combat scene to render a wizardry-style interface via a dedicated CombatUI, including party panels, enemy display, and command buttons
- preload the battle background and zombie art that the new combat presentation depends on

## Testing
- npx vite build --config vite/config.prod.mjs

------
https://chatgpt.com/codex/tasks/task_e_68caea3ae628832789d94174f6f6db04