### PR TITLE
Refine combat formation layout with ally portraits

### DIFF
--- a/src/features/combat/data/enemies.js
+++ b/src/features/combat/data/enemies.js
@@ -1,20 +1,62 @@
+import { cloneFormation } from './formation.js';
+
 export const DEFAULT_COMBAT_BACKGROUND = 'combatBackgroundForest';
 
 const ENEMIES = [
   {
-    id: 'crypt-zombie',
-    name: 'Crypt Zombie',
+    id: 'crypt-zombie-pack',
+    name: 'Crypt Zombie Pack',
     level: 3,
     texture: 'monsterZombie',
-    description: 'A shambling corpse animated by dungeon miasma.',
+    description: 'A shambling horde animated by dungeon miasma. Their frontliners shield the cult adepts weaving foul magic in the rear.',
     maxHp: 90,
     currentHp: 90,
     backgroundKey: DEFAULT_COMBAT_BACKGROUND,
+    formation: {
+      front: [
+        {
+          id: 'crypt-zombie-vanguard-a',
+          name: 'Crypt Zombie',
+          texture: 'monsterZombie',
+          maxHp: 90,
+          currentHp: 90,
+        },
+        {
+          id: 'crypt-zombie-vanguard-b',
+          name: 'Crypt Zombie',
+          texture: 'monsterZombie',
+          maxHp: 90,
+          currentHp: 90,
+        },
+      ],
+      back: [
+        {
+          id: 'crypt-zombie-occultist-a',
+          name: 'Occult Ghoul',
+          texture: 'monsterZombie',
+          maxHp: 75,
+          currentHp: 75,
+        },
+        {
+          id: 'crypt-zombie-occultist-b',
+          name: 'Fetid Acolyte',
+          texture: 'monsterZombie',
+          maxHp: 75,
+          currentHp: 75,
+        },
+      ],
+    },
   },
 ];
 
 function cloneEnemy(enemy) {
-  return { ...enemy };
+  const cloned = { ...enemy };
+
+  if (enemy.formation) {
+    cloned.formation = cloneFormation(enemy.formation);
+  }
+
+  return cloned;
 }
 
 export function getRandomEnemy(randomFn = Math.random) {

--- a/src/features/combat/data/formation.js
+++ b/src/features/combat/data/formation.js
@@ -1,0 +1,159 @@
+export const FORMATION_ROWS = ['front', 'back'];
+export const FORMATION_COLUMNS = 2;
+
+export function createEmptyFormation() {
+  return FORMATION_ROWS.reduce((acc, rowKey) => {
+    acc[rowKey] = Array.from({ length: FORMATION_COLUMNS }, () => null);
+    return acc;
+  }, {});
+}
+
+export function cloneFormation(formation) {
+  if (!formation || typeof formation !== 'object') {
+    return createEmptyFormation();
+  }
+
+  const clone = createEmptyFormation();
+
+  FORMATION_ROWS.forEach((rowKey) => {
+    const row = Array.isArray(formation[rowKey]) ? formation[rowKey] : [];
+    clone[rowKey] = row.slice(0, FORMATION_COLUMNS).map((slot) => (slot ? { ...slot } : null));
+  });
+
+  return clone;
+}
+
+export function formationHasUnits(formation) {
+  if (!formation || typeof formation !== 'object') {
+    return false;
+  }
+
+  return FORMATION_ROWS.some((rowKey) => {
+    const row = formation[rowKey];
+    return Array.isArray(row) && row.some((slot) => slot != null);
+  });
+}
+
+export function assignUnitsToFormation(units = [], options = {}) {
+  const {
+    mutate = false,
+    defaultRows = ['front', 'front', 'back', 'back'],
+  } = options;
+
+  const workingUnits = mutate ? units : units.map((unit) => (unit ? { ...unit } : unit));
+  const formation = createEmptyFormation();
+  const normalizedDefaults = Array.isArray(defaultRows) && defaultRows.length > 0
+    ? defaultRows
+    : FORMATION_ROWS;
+
+  workingUnits.forEach((unit, index) => {
+    if (!unit) {
+      return;
+    }
+
+    const fallbackRow = normalizedDefaults[Math.min(index, normalizedDefaults.length - 1)] ?? 'back';
+    const desiredRow = sanitizeRow(unit.battleRow, fallbackRow);
+    const explicitColumn = Number.isInteger(unit.battleColumn)
+      ? clampColumn(unit.battleColumn)
+      : null;
+
+    const placement = reserveSlot(formation, desiredRow, explicitColumn, fallbackRow);
+    const assignedUnit = mutate ? unit : workingUnits[index];
+
+    assignedUnit.battleRow = placement.row;
+    assignedUnit.battleColumn = placement.column;
+    formation[placement.row][placement.column] = assignedUnit;
+  });
+
+  return { formation, units: workingUnits };
+}
+
+export function normalizeFormationStructure(input, { mapUnit } = {}) {
+  const formation = createEmptyFormation();
+
+  if (!input || typeof input !== 'object') {
+    return { formation };
+  }
+
+  const source = input.rows && typeof input.rows === 'object'
+    ? input.rows
+    : input;
+
+  FORMATION_ROWS.forEach((rowKey) => {
+    const row = Array.isArray(source[rowKey]) ? source[rowKey] : [];
+
+    row.slice(0, FORMATION_COLUMNS).forEach((unitLike, columnIndex) => {
+      if (unitLike && typeof unitLike === 'object') {
+        const mapped = mapUnit ? mapUnit(unitLike, rowKey, columnIndex) : { ...unitLike };
+
+        if (mapped) {
+          mapped.battleRow = rowKey;
+          mapped.battleColumn = columnIndex;
+          formation[rowKey][columnIndex] = mapped;
+        }
+      }
+    });
+  });
+
+  return { formation };
+}
+
+function sanitizeRow(row, fallback) {
+  if (FORMATION_ROWS.includes(row)) {
+    return row;
+  }
+
+  if (FORMATION_ROWS.includes(fallback)) {
+    return fallback;
+  }
+
+  return FORMATION_ROWS[FORMATION_ROWS.length - 1];
+}
+
+function clampColumn(column) {
+  return Math.min(Math.max(column, 0), FORMATION_COLUMNS - 1);
+}
+
+function reserveSlot(formation, row, explicitColumn, fallbackRow) {
+  const rowKey = sanitizeRow(row, fallbackRow);
+  const rowSlots = formation[rowKey];
+
+  if (explicitColumn != null && rowSlots[explicitColumn] == null) {
+    return { row: rowKey, column: explicitColumn };
+  }
+
+  if (explicitColumn != null && rowSlots[explicitColumn] != null) {
+    const alternativeColumn = rowSlots.findIndex((slot) => slot == null);
+    if (alternativeColumn !== -1) {
+      return { row: rowKey, column: alternativeColumn };
+    }
+  }
+
+  if (explicitColumn == null) {
+    const availableColumn = rowSlots.findIndex((slot) => slot == null);
+    if (availableColumn !== -1) {
+      return { row: rowKey, column: availableColumn };
+    }
+  }
+
+  const alternativeRow = FORMATION_ROWS.find((candidate) => {
+    if (candidate === rowKey) {
+      return false;
+    }
+
+    return formation[candidate].some((slot) => slot == null);
+  });
+
+  if (alternativeRow) {
+    const alternativeColumn = formation[alternativeRow].findIndex((slot) => slot == null);
+    if (alternativeColumn !== -1) {
+      return { row: alternativeRow, column: alternativeColumn };
+    }
+  }
+
+  const fallbackColumn = explicitColumn != null
+    ? clampColumn(explicitColumn)
+    : rowSlots.length - 1;
+
+  return { row: rowKey, column: fallbackColumn };
+}

--- a/src/features/combat/data/partyRoster.js
+++ b/src/features/combat/data/partyRoster.js
@@ -8,6 +8,9 @@ const BASE_PARTY = [
     currentHp: 120,
     maxMp: 8,
     currentMp: 8,
+    battleRow: 'front',
+    battleColumn: 0,
+    portraitTexture: 'portrait-warrior',
   },
   {
     id: 'brann',
@@ -18,6 +21,9 @@ const BASE_PARTY = [
     currentHp: 95,
     maxMp: 18,
     currentMp: 18,
+    battleRow: 'front',
+    battleColumn: 1,
+    portraitTexture: 'portrait-gunner',
   },
   {
     id: 'celine',
@@ -28,6 +34,9 @@ const BASE_PARTY = [
     currentHp: 70,
     maxMp: 52,
     currentMp: 52,
+    battleRow: 'back',
+    battleColumn: 0,
+    portraitTexture: 'portrait-esper',
   },
   {
     id: 'dorian',
@@ -38,6 +47,9 @@ const BASE_PARTY = [
     currentHp: 88,
     maxMp: 44,
     currentMp: 44,
+    battleRow: 'back',
+    battleColumn: 1,
+    portraitTexture: 'portrait-paladin',
   },
 ];
 

--- a/src/features/combat/ui/CombatUI.js
+++ b/src/features/combat/ui/CombatUI.js
@@ -1,5 +1,13 @@
 import { MeasurementManager } from '../../../MeasurementManager.js';
 import { DEFAULT_COMBAT_BACKGROUND } from '../data/enemies.js';
+import {
+  assignUnitsToFormation,
+  cloneFormation,
+  createEmptyFormation,
+  FORMATION_COLUMNS,
+  FORMATION_ROWS,
+  formationHasUnits,
+} from '../data/formation.js';
 
 const UI_COLORS = {
   overlay: 0x000000,
@@ -10,6 +18,13 @@ const UI_COLORS = {
   rowHover: 0x193452,
   enemyFrame: 0x0d1422,
   enemyFrameStroke: 0x4aa3ff,
+  partyFrontSlot: 0x1d3557,
+  partyBackSlot: 0x14233c,
+  partySlotStroke: 0x5ec5ff,
+  enemyFrontSlot: 0x5b1d1d,
+  enemyBackSlot: 0x351010,
+  enemySlotStroke: 0xff9171,
+  slotPlaceholder: 0x1f2a3a,
 };
 
 const UI_ALPHA = {
@@ -17,6 +32,29 @@ const UI_ALPHA = {
   panel: 0.78,
   row: 0.92,
   enemyFrame: 0.68,
+  slot: 0.88,
+  slotBack: 0.82,
+};
+
+const FORMATION_STYLES = {
+  party: {
+    front: { fill: UI_COLORS.partyFrontSlot, alpha: UI_ALPHA.slot },
+    back: { fill: UI_COLORS.partyBackSlot, alpha: UI_ALPHA.slotBack },
+    stroke: { color: UI_COLORS.partySlotStroke, alpha: 0.95 },
+    labelColor: '#7cc4ff',
+    nameColor: '#ffffff',
+    hpColor: '#9afff7',
+    emptyColor: '#6c7ba0',
+  },
+  enemy: {
+    front: { fill: UI_COLORS.enemyFrontSlot, alpha: UI_ALPHA.slot },
+    back: { fill: UI_COLORS.enemyBackSlot, alpha: UI_ALPHA.slotBack },
+    stroke: { color: UI_COLORS.enemySlotStroke, alpha: 0.95 },
+    labelColor: '#ffb59f',
+    nameColor: '#ffe7d6',
+    hpColor: '#ffb4a2',
+    emptyColor: '#8d5151',
+  },
 };
 
 const COMMANDS = [
@@ -34,11 +72,23 @@ export class CombatUI {
     this.commandButtons = [];
   }
 
-  render({ party = [], enemy = {}, backgroundKey = DEFAULT_COMBAT_BACKGROUND, hint } = {}) {
+  render({
+    party = [],
+    partyFormation,
+    enemy = {},
+    enemyFormation,
+    backgroundKey = DEFAULT_COMBAT_BACKGROUND,
+    hint,
+  } = {}) {
     this.clear();
 
     this.drawBackground(backgroundKey);
-    this.drawEnemy(enemy);
+    this.drawBattlefield({
+      party,
+      partyFormation,
+      enemy,
+      enemyFormation,
+    });
     this.drawPartyPanel(party);
     this.drawCommandPanel();
 
@@ -88,93 +138,310 @@ export class CombatUI {
     overlay.setDepth(-1);
   }
 
-  drawEnemy(enemy) {
-    const { centerX, centerY } = MeasurementManager;
-    const frameWidth = 420;
-    const frameHeight = 320;
-    const frameY = centerY - 170;
+  drawBattlefield({ party, partyFormation, enemy, enemyFormation }) {
+    const resolvedEnemyFormation = this.resolveEnemyFormation(enemyFormation ?? enemy?.formation);
+    const resolvedPartyFormation = this.resolvePartyFormation(partyFormation, party);
 
-    const frame = this.register(
-      this.scene.add.rectangle(centerX, frameY, frameWidth, frameHeight, UI_COLORS.enemyFrame, UI_ALPHA.enemyFrame)
-    );
-    frame.setStrokeStyle(2, UI_COLORS.enemyFrameStroke);
+    this.drawEncounterHeader(enemy);
+    this.drawFormationSide('enemy', resolvedEnemyFormation);
+    this.drawFormationSide('party', resolvedPartyFormation, {
+      title: 'Adventuring Party',
+    });
+  }
 
-    const frameTop = frameY - frameHeight / 2;
-    const frameBottom = frameY + frameHeight / 2;
+  drawEncounterHeader(enemy = {}) {
+    const { centerX, screenWidth } = MeasurementManager;
+    const headerY = 48;
 
     const title = this.register(
-      this.scene.add.text(centerX, frameTop + 18, enemy.name ?? 'Unknown Foe', {
+      this.scene.add.text(centerX, headerY, enemy.name ?? 'Enemy Forces', {
         fontFamily: 'Arial Black',
-        fontSize: '28px',
-        color: '#ffffff',
+        fontSize: '30px',
+        color: '#ffe7c1',
         align: 'center',
       })
     );
-    title.setOrigin(0.5, 0);
+    title.setOrigin(0.5, 0.5);
 
     if (enemy.level) {
-      const levelBadge = this.register(
-        this.scene.add.text(frame.x + frameWidth / 2 - 16, frameTop + 18, `Lv ${enemy.level}`, {
+      const levelText = this.register(
+        this.scene.add.text(centerX, headerY + 30, `Encounter Level ${enemy.level}`, {
           fontFamily: 'Arial',
           fontSize: '18px',
-          color: '#8cb1ff',
+          color: '#ffd19a',
         })
       );
-      levelBadge.setOrigin(1, 0);
-    }
-
-    if (enemy.texture && this.scene.textures.exists(enemy.texture)) {
-      const sprite = this.register(
-        this.scene.add.image(centerX, frameBottom - 24, enemy.texture)
-      );
-      sprite.setOrigin(0.5, 1);
-      const maxWidth = frameWidth - 80;
-      const maxHeight = frameHeight - 96;
-      const baseWidth = sprite.width || maxWidth;
-      const baseHeight = sprite.height || maxHeight;
-      const scale = Math.min(maxWidth / baseWidth, maxHeight / baseHeight);
-      if (Number.isFinite(scale) && scale > 0) {
-        sprite.setScale(scale);
-      } else {
-        sprite.setDisplaySize(maxWidth, maxHeight);
-      }
-    } else {
-      const placeholder = this.register(
-        this.scene.add.rectangle(centerX, frameBottom - 60, frameWidth - 100, frameHeight - 140, UI_COLORS.row, UI_ALPHA.row)
-      );
-      placeholder.setOrigin(0.5, 1);
-      placeholder.setStrokeStyle(2, UI_COLORS.rowStroke);
-
-      const placeholderText = this.register(
-        this.scene.add.text(centerX, frameBottom - 140, 'No enemy art', {
-          fontFamily: 'Arial',
-          fontSize: '20px',
-          color: '#d0d6ff',
-        })
-      );
-      placeholderText.setOrigin(0.5, 0.5);
+      levelText.setOrigin(0.5, 0.5);
+      levelText.setAlpha(0.9);
     }
 
     if (enemy.description) {
       const description = this.register(
-        this.scene.add.text(centerX, frameBottom + 18, enemy.description, {
+        this.scene.add.text(centerX, headerY + 60, enemy.description, {
           fontFamily: 'Arial',
           fontSize: '18px',
           color: '#d0d6ff',
           align: 'center',
-          wordWrap: { width: frameWidth + 160 },
+          wordWrap: { width: screenWidth - 160 },
         })
       );
-      description.setOrigin(0.5, 0);
-      description.setAlpha(0.92);
+      description.setOrigin(0.5, 0.5);
+      description.setAlpha(0.9);
     }
   }
 
+  drawFormationSide(side, formation, options = {}) {
+    const config = this.getFormationConfig(side);
+    const columnPositions = this.getColumnPositions(config);
+    const rowCenter = (columnPositions[0] + columnPositions[columnPositions.length - 1]) / 2;
+    const hasUnits = formationHasUnits(formation);
+
+    if (options.title) {
+      const title = this.register(
+        this.scene.add.text(rowCenter, config.backRowY - config.slotHeight / 2 - 30, options.title, {
+          fontFamily: 'Arial Black',
+          fontSize: '20px',
+          color: side === 'party' ? '#9ad8ff' : '#ffb59f',
+          align: 'center',
+        })
+      );
+      title.setOrigin(0.5, 0.5);
+    }
+
+    ['back', 'front'].forEach((rowKey) => {
+      const rowY = rowKey === 'front' ? config.frontRowY : config.backRowY;
+      const rowLabel = this.register(
+        this.scene.add.text(rowCenter, rowY - config.slotHeight / 2 - 22, this.getRowLabel(rowKey), {
+          fontFamily: 'Arial',
+          fontSize: '16px',
+          color: FORMATION_STYLES[side].labelColor,
+          align: 'center',
+        })
+      );
+      rowLabel.setOrigin(0.5, 0.5);
+      rowLabel.setAlpha(0.85);
+
+      columnPositions.forEach((x, columnIndex) => {
+        const unit = formation?.[rowKey]?.[columnIndex] ?? null;
+        this.drawFormationSlot({
+          x,
+          y: rowY,
+          width: config.slotWidth,
+          height: config.slotHeight,
+          unit,
+          side,
+          rowKey,
+        });
+      });
+    });
+
+    if (!hasUnits) {
+      const placeholder = this.register(
+        this.scene.add.text(rowCenter, (config.backRowY + config.frontRowY) / 2, side === 'party' ? 'No allies deployed' : 'No foes present', {
+          fontFamily: 'Arial',
+          fontSize: '18px',
+          color: FORMATION_STYLES[side].emptyColor,
+          align: 'center',
+        })
+      );
+      placeholder.setOrigin(0.5, 0.5);
+      placeholder.setAlpha(0.75);
+    }
+  }
+
+  getFormationConfig(side) {
+    const slotWidth = 148;
+    const slotHeight = 152;
+    const columnSpacing = 28;
+    const rowSpacing = 34;
+    const baseSpacing = slotHeight + rowSpacing;
+
+    if (side === 'enemy') {
+      const backRowY = MeasurementManager.centerY - baseSpacing - 32;
+      const frontRowY = backRowY + baseSpacing;
+      return {
+        side,
+        align: 'left',
+        originX: 200,
+        slotWidth,
+        slotHeight,
+        columnSpacing,
+        backRowY,
+        frontRowY,
+      };
+    }
+
+    const backRowY = MeasurementManager.centerY + 24;
+    const frontRowY = backRowY + baseSpacing;
+    return {
+      side,
+      align: 'right',
+      originX: MeasurementManager.screenWidth - 200,
+      slotWidth,
+      slotHeight,
+      columnSpacing,
+      backRowY,
+      frontRowY,
+    };
+  }
+
+  getColumnPositions(config) {
+    return Array.from({ length: FORMATION_COLUMNS }, (_, columnIndex) => {
+      const offset = columnIndex * (config.slotWidth + config.columnSpacing);
+      return config.align === 'right'
+        ? config.originX - offset
+        : config.originX + offset;
+    });
+  }
+
+  getRowLabel(rowKey) {
+    if (rowKey === 'front') {
+      return 'FRONT ROW';
+    }
+    if (rowKey === 'back') {
+      return 'BACK ROW';
+    }
+    return 'FORMATION';
+  }
+
+  drawFormationSlot({ x, y, width, height, unit, side, rowKey }) {
+    const style = FORMATION_STYLES[side];
+    const rowStyle = style[rowKey === 'front' ? 'front' : 'back'];
+
+    const slot = this.register(
+      this.scene.add.rectangle(x, y, width, height, rowStyle.fill, rowStyle.alpha)
+    );
+    slot.setOrigin(0.5, 0.5);
+    slot.setStrokeStyle(2, style.stroke.color, style.stroke.alpha);
+
+    if (unit) {
+      const textureKey = this.resolveUnitTexture(unit, side);
+
+      if (textureKey && this.scene.textures.exists(textureKey)) {
+        const art = this.register(
+          this.scene.add.image(x, y - 12, textureKey)
+        );
+        this.fitImage(art, width - 28, height - 64);
+      } else {
+        const placeholder = this.register(
+          this.scene.add.rectangle(x, y - 18, width - 36, height - 96, UI_COLORS.slotPlaceholder, 0.6)
+        );
+        placeholder.setOrigin(0.5, 0.5);
+        placeholder.setStrokeStyle(1, style.stroke.color, 0.45);
+
+        const placeholderText = this.register(
+          this.scene.add.text(x, y - 18, '???', {
+            fontFamily: 'Arial Black',
+            fontSize: '24px',
+            color: '#ffffff',
+          })
+        );
+        placeholderText.setOrigin(0.5, 0.5);
+      }
+
+      const name = unit.name ?? unit.id ?? 'Unknown';
+      const nameText = this.register(
+        this.scene.add.text(x, y + height / 2 - 36, name, {
+          fontFamily: 'Arial',
+          fontSize: '16px',
+          color: style.nameColor,
+          align: 'center',
+          wordWrap: { width: width - 20 },
+        })
+      );
+      nameText.setOrigin(0.5, 0.5);
+
+      if (unit.currentHp != null && unit.maxHp != null) {
+        const hpText = this.register(
+          this.scene.add.text(x, y + height / 2 - 16, `HP ${unit.currentHp}/${unit.maxHp}`, {
+            fontFamily: 'Courier',
+            fontSize: '14px',
+            color: style.hpColor,
+          })
+        );
+        hpText.setOrigin(0.5, 0.5);
+      }
+    } else {
+      const emptyText = this.register(
+        this.scene.add.text(x, y, 'Empty', {
+          fontFamily: 'Arial',
+          fontSize: '18px',
+          color: style.emptyColor,
+        })
+      );
+      emptyText.setOrigin(0.5, 0.5);
+    }
+  }
+
+  resolvePartyFormation(partyFormation, party) {
+    if (this.isFormationValid(partyFormation)) {
+      return cloneFormation(partyFormation);
+    }
+
+    if (Array.isArray(party) && party.length > 0) {
+      const { formation } = assignUnitsToFormation(party, { mutate: false });
+      return formation;
+    }
+
+    return createEmptyFormation();
+  }
+
+  resolveEnemyFormation(enemyFormation) {
+    if (this.isFormationValid(enemyFormation)) {
+      return cloneFormation(enemyFormation);
+    }
+
+    return createEmptyFormation();
+  }
+
+  isFormationValid(formation) {
+    return formation && typeof formation === 'object' && FORMATION_ROWS.every((rowKey) => Array.isArray(formation[rowKey]));
+  }
+
+  resolveUnitTexture(unit, side) {
+    if (!unit) {
+      return null;
+    }
+
+    if (side === 'party') {
+      return unit.portraitTexture ?? unit.portrait ?? unit.texture ?? null;
+    }
+
+    return unit.texture ?? unit.portraitTexture ?? null;
+  }
+
+  fitImage(image, maxWidth, maxHeight) {
+    const baseWidth = image.width || maxWidth;
+    const baseHeight = image.height || maxHeight;
+    const scale = Math.min(maxWidth / baseWidth, maxHeight / baseHeight);
+
+    if (Number.isFinite(scale) && scale > 0) {
+      image.setScale(scale);
+    } else {
+      image.setDisplaySize(maxWidth, maxHeight);
+    }
+  }
+
+  buildPartyInfoLine(member) {
+    const rowLabel = this.formatRowLabel(member?.battleRow);
+    return `Lv ${member?.level ?? 1} · ${rowLabel} · ${member?.role ?? 'Adventurer'}`;
+  }
+
+  formatRowLabel(row) {
+    if (row === 'front') {
+      return 'Front Row';
+    }
+    if (row === 'back') {
+      return 'Back Row';
+    }
+    return 'Reserve';
+  }
+
   drawPartyPanel(party) {
-    const panelPadding = 14;
-    const rowHeight = 60;
+    const panelPadding = 16;
+    const rowHeight = 88;
     const rowGap = 10;
-    const width = 360;
+    const width = 420;
     const rows = Math.max(party.length, 1);
     const height = panelPadding * 2 + rows * rowHeight + (rows - 1) * rowGap;
     const startX = 48;
@@ -186,17 +453,45 @@ export class CombatUI {
     panel.setOrigin(0, 0);
     panel.setStrokeStyle(2, UI_COLORS.panelStroke);
 
+    const portraitSize = 60;
+
     party.forEach((member, index) => {
       const rowY = startY + panelPadding + index * (rowHeight + rowGap);
-
       const row = this.register(
         this.scene.add.rectangle(startX + panelPadding, rowY, width - panelPadding * 2, rowHeight, UI_COLORS.row, UI_ALPHA.row)
       );
       row.setOrigin(0, 0);
       row.setStrokeStyle(2, UI_COLORS.rowStroke);
 
+      const portraitCenterX = startX + panelPadding + portraitSize / 2;
+      const portraitCenterY = rowY + rowHeight / 2;
+      const portraitKey = this.resolveUnitTexture(member, 'party');
+
+      if (portraitKey && this.scene.textures.exists(portraitKey)) {
+        const portrait = this.register(
+          this.scene.add.image(portraitCenterX, portraitCenterY, portraitKey)
+        );
+        this.fitImage(portrait, portraitSize, portraitSize);
+      } else {
+        const portraitPlaceholder = this.register(
+          this.scene.add.rectangle(portraitCenterX, portraitCenterY, portraitSize - 8, portraitSize - 8, UI_COLORS.slotPlaceholder, 0.7)
+        );
+        portraitPlaceholder.setStrokeStyle(1, UI_COLORS.rowStroke, 0.6);
+
+        const placeholderText = this.register(
+          this.scene.add.text(portraitCenterX, portraitCenterY, '?', {
+            fontFamily: 'Arial Black',
+            fontSize: '24px',
+            color: '#ffffff',
+          })
+        );
+        placeholderText.setOrigin(0.5, 0.5);
+      }
+
+      const textStartX = startX + panelPadding + portraitSize + 16;
+
       const nameText = this.register(
-        this.scene.add.text(startX + panelPadding + 12, rowY + 6, member.name ?? 'Unknown', {
+        this.scene.add.text(textStartX, rowY + 8, member.name ?? 'Unknown', {
           fontFamily: 'Arial',
           fontSize: '20px',
           color: '#ffffff',
@@ -204,17 +499,17 @@ export class CombatUI {
       );
       nameText.setOrigin(0, 0);
 
-      const roleText = this.register(
-        this.scene.add.text(startX + panelPadding + 12, rowY + 32, `Lv ${member.level ?? 1} · ${member.role ?? 'Adventurer'}`, {
+      const infoText = this.register(
+        this.scene.add.text(textStartX, rowY + 36, this.buildPartyInfoLine(member), {
           fontFamily: 'Arial',
           fontSize: '16px',
           color: '#8cb1ff',
         })
       );
-      roleText.setOrigin(0, 0);
+      infoText.setOrigin(0, 0);
 
       const hpText = this.register(
-        this.scene.add.text(startX + width - panelPadding - 12, rowY + 10, `HP ${member.currentHp ?? 0}/${member.maxHp ?? 0}`, {
+        this.scene.add.text(startX + width - panelPadding - 12, rowY + 16, `HP ${member.currentHp ?? 0}/${member.maxHp ?? 0}`, {
           fontFamily: 'Courier',
           fontSize: '18px',
           color: '#7ce8ff',
@@ -223,7 +518,7 @@ export class CombatUI {
       hpText.setOrigin(1, 0);
 
       const mpText = this.register(
-        this.scene.add.text(startX + width - panelPadding - 12, rowY + 32, `MP ${member.currentMp ?? 0}/${member.maxMp ?? 0}`, {
+        this.scene.add.text(startX + width - panelPadding - 12, rowY + 40, `MP ${member.currentMp ?? 0}/${member.maxMp ?? 0}`, {
           fontFamily: 'Courier',
           fontSize: '16px',
           color: '#caa4ff',
@@ -231,6 +526,20 @@ export class CombatUI {
       );
       mpText.setOrigin(1, 0);
     });
+
+    if (party.length === 0) {
+      const placeholder = this.register(
+        this.scene.add.text(startX + width / 2, startY + height / 2, 'No party members assigned', {
+          fontFamily: 'Arial',
+          fontSize: '18px',
+          color: '#d0d6ff',
+          align: 'center',
+          wordWrap: { width: width - panelPadding * 2 },
+        })
+      );
+      placeholder.setOrigin(0.5, 0.5);
+      placeholder.setAlpha(0.8);
+    }
   }
 
   drawCommandPanel() {

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -45,6 +45,10 @@ export class Preloader extends Scene
         this.load.image('dungeonFloor', 'images/dungeon/tilesets/floor-tile-1.png');
         this.load.image('dungeonWall', 'images/dungeon/tilesets/wall-tile-1.png');
         this.load.image('playerWarrior', 'images/characters/unit/warrior.png');
+        this.load.image('portrait-warrior', 'images/characters/unit/warrior-ui.png');
+        this.load.image('portrait-gunner', 'images/characters/unit/gunner-ui.png');
+        this.load.image('portrait-esper', 'images/characters/unit/esper-ui.png');
+        this.load.image('portrait-paladin', 'images/characters/unit/paladin-ui.png');
         this.load.image('combatBackgroundForest', 'images/battle/backgrounds/battle-stage-cursed-forest.png');
         this.load.image('monsterZombie', 'images/characters/monsters/zombie.png');
     }

--- a/src/game/states/CombatState.js
+++ b/src/game/states/CombatState.js
@@ -4,6 +4,7 @@ import { debugLogManager } from '../../utils/DebugLogManager.js';
 import { CombatUI } from '../../features/combat/ui/CombatUI.js';
 import { createBasePartyRoster } from '../../features/combat/data/partyRoster.js';
 import { DEFAULT_COMBAT_BACKGROUND, getDefaultEnemy } from '../../features/combat/data/enemies.js';
+import { assignUnitsToFormation, formationHasUnits, normalizeFormationStructure } from '../../features/combat/data/formation.js';
 
 export class CombatState extends Scene {
   constructor() {
@@ -29,7 +30,9 @@ export class CombatState extends Scene {
 
     this.combatUI.render({
       party: preparedEncounter.party,
+      partyFormation: preparedEncounter.partyFormation,
       enemy: preparedEncounter.enemy,
+      enemyFormation: preparedEncounter.enemyFormation,
       backgroundKey: preparedEncounter.backgroundKey,
       hint: 'Press ESC to return to exploration',
     });
@@ -39,9 +42,12 @@ export class CombatState extends Scene {
 
   prepareEncounterData(data = {}) {
     const enemy = this.normalizeEnemyData(data.enemy);
+    const partyData = this.normalizePartyData(data.party);
     return {
-      party: this.normalizePartyData(data.party),
+      party: partyData.members,
+      partyFormation: partyData.formation,
       enemy,
+      enemyFormation: enemy.formation,
       backgroundKey: data.backgroundKey ?? enemy.backgroundKey ?? DEFAULT_COMBAT_BACKGROUND,
     };
   }
@@ -51,7 +57,7 @@ export class CombatState extends Scene {
       ? partyData
       : createBasePartyRoster();
 
-    return source.map((member) => {
+    const normalizedMembers = source.map((member) => {
       const maxHp = this.safeNumber(member.maxHp ?? member.hp ?? member.currentHp, 0);
       const currentHp = this.safeNumber(member.currentHp ?? member.hp ?? maxHp, maxHp);
       const maxMp = this.safeNumber(member.maxMp ?? member.mp ?? member.currentMp, 0);
@@ -65,8 +71,16 @@ export class CombatState extends Scene {
         currentHp,
         maxMp,
         currentMp,
+        portraitTexture: member.portraitTexture ?? member.portrait ?? null,
       };
     });
+
+    const { formation, units } = assignUnitsToFormation(normalizedMembers, {
+      mutate: true,
+      defaultRows: ['front', 'front', 'back', 'back'],
+    });
+
+    return { members: units, formation };
   }
 
   normalizeEnemyData(enemyData) {
@@ -74,6 +88,43 @@ export class CombatState extends Scene {
     enemy.maxHp = this.safeNumber(enemy.maxHp ?? enemy.currentHp, 0);
     enemy.currentHp = this.safeNumber(enemy.currentHp ?? enemy.maxHp, enemy.maxHp);
     enemy.level = enemy.level ?? 1;
+    enemy.texture = enemy.texture ?? 'monsterZombie';
+
+    const { formation } = normalizeFormationStructure(enemy.formation, {
+      mapUnit: (unitLike) => {
+        const mapped = { ...unitLike };
+        mapped.name = mapped.name ?? enemy.name ?? 'Enemy';
+        mapped.texture = mapped.texture ?? enemy.texture;
+        mapped.level = mapped.level ?? enemy.level;
+        mapped.maxHp = this.safeNumber(mapped.maxHp ?? mapped.currentHp, enemy.maxHp);
+        mapped.currentHp = this.safeNumber(mapped.currentHp ?? mapped.maxHp, mapped.maxHp);
+        return mapped;
+      },
+    });
+
+    if (!formationHasUnits(formation)) {
+      const duplicateUnits = [
+        { id: `${enemy.id ?? 'enemy'}-front-a`, name: enemy.name },
+        { id: `${enemy.id ?? 'enemy'}-front-b`, name: enemy.name },
+        { id: `${enemy.id ?? 'enemy'}-back-a`, name: enemy.name },
+        { id: `${enemy.id ?? 'enemy'}-back-b`, name: enemy.name },
+      ].map((unit) => ({
+        ...unit,
+        texture: enemy.texture,
+        level: enemy.level,
+        maxHp: enemy.maxHp,
+        currentHp: enemy.currentHp,
+      }));
+
+      const { formation: fallbackFormation } = assignUnitsToFormation(duplicateUnits, {
+        mutate: true,
+      });
+
+      enemy.formation = fallbackFormation;
+    } else {
+      enemy.formation = formation;
+    }
+
     return enemy;
   }
 


### PR DESCRIPTION
## Summary
- add shared formation utilities and update base party/enemy data to define front and back rows
- preload ally portrait textures and normalize combat state data so encounters expose formation layouts
- redesign the combat UI to render two-row formations for both sides with ally portraits and enhanced party status panel

## Testing
- npm run build-nolog

------
https://chatgpt.com/codex/tasks/task_e_68caf25045d88327a1c9412be30bc581